### PR TITLE
voters-list: capture maintainer names & emails from MAINTAINERS files

### DIFF
--- a/elections/2026/voters-list/email-to-github.csv
+++ b/elections/2026/voters-list/email-to-github.csv
@@ -1,0 +1,17 @@
+# Mapping from maintainer email -> GitHub login.
+#
+# Some MAINTAINERS files list a person by name and email only (no @handle), or
+# with a handle that doesn't resolve. This file maps such emails to the correct
+# GitHub login so the maintainer is matched against the write-access set instead
+# of landing in maintainers-without-write-access.csv.
+#
+# Format: email,github_id (one per line; lines starting with # are ignored).
+# The mapping takes precedence over the handle parsed from the MAINTAINERS file.
+email,github_id
+superq@gmail.com,SuperQ
+julius.volz@gmail.com,juliusv
+pasquier.simon@gmail.com,simonpasquier
+richih@richih.org,RichiH
+dmagliola@crystalgears.com,dmagliola
+tobidt@gmail.com,grobie
+kobi.zamir@gmail.com,yaacov

--- a/elections/2026/voters-list/main.go
+++ b/elections/2026/voters-list/main.go
@@ -4,9 +4,20 @@
 // Lists org members and per-repo direct collaborators with push permission.
 // Requires admin access on each org/repo for the collaborators listing.
 //
+// It also reads each repo's root MAINTAINERS(.md) file to capture maintainer
+// names and emails: these enrich the write-access list where a maintainer's
+// GitHub handle matches a known login, and maintainers not in the write-access
+// set are written to maintainers-without-write-access.csv (they do not become
+// voters).
+//
+// A mapping file (-mapping, default email-to-github.csv) maps maintainer emails
+// to GitHub logins. It resolves MAINTAINERS entries that list a person by
+// name+email only (no @handle), or with a handle that needs correcting, so they
+// match the write-access set.
+//
 // Usage:
 //
-//	collect-write-access [-out <dir>]
+//	collect-write-access [-out <dir>] [-mapping <file>]
 //
 // Auth: reads GITHUB_TOKEN env var, or falls back to `gh auth token`.
 package main
@@ -21,9 +32,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/go-github/v66/github"
 )
@@ -45,27 +58,46 @@ type ManifestEntry struct {
 	FetchedAt string `json:"fetched_at"`
 }
 
-// Writer is one (login, source, access_type) triple.
+// Writer is one (login, source, access_type) triple. Name and Email are only
+// populated for rows sourced from a MAINTAINERS file (access_type "maintainer").
 type Writer struct {
 	Login      string
 	Source     string
 	AccessType string
+	Name       string
+	Email      string
+}
+
+// Maintainer is one entry parsed from a repo's root MAINTAINERS(.md) file.
+type Maintainer struct {
+	Org    string
+	Repo   string
+	Name   string
+	Email  string
+	Handle string // GitHub login, without the leading "@"; may be empty.
 }
 
 func main() {
 	outDir := flag.String("out", "out-access", "output directory")
+	mappingPath := flag.String("mapping", "email-to-github.csv", "email->github login mapping file")
 	flag.Parse()
 
-	if err := run(*outDir); err != nil {
+	if err := run(*outDir, *mappingPath); err != nil {
 		logf("ERROR: %v", err)
 		os.Exit(1)
 	}
 }
 
-func run(outDir string) error {
+func run(outDir, mappingPath string) error {
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return fmt.Errorf("create out dir: %w", err)
 	}
+
+	emailToLogin, err := loadEmailMapping(mappingPath)
+	if err != nil {
+		return fmt.Errorf("load mapping: %w", err)
+	}
+	logf("Loaded %d email->github mappings from %s", len(emailToLogin), mappingPath)
 
 	token, err := resolveToken()
 	if err != nil {
@@ -78,8 +110,9 @@ func run(outDir string) error {
 	generatedAt := time.Now().UTC().Format(time.RFC3339)
 
 	var (
-		writers  []Writer
-		manifest []ManifestEntry
+		writers     []Writer
+		maintainers []Maintainer
+		manifest    []ManifestEntry
 	)
 
 	// Org members.
@@ -106,9 +139,9 @@ func run(outDir string) error {
 		logf("OK   %s — %d org members", org, len(members))
 	}
 
-	// Direct collaborators per repo.
+	// Direct collaborators and MAINTAINERS files per repo.
 	for _, org := range orgs {
-		logf("Enumerating repos in %s for direct collaborators …", org)
+		logf("Enumerating repos in %s for direct collaborators and maintainers …", org)
 		repos, err := listNonArchivedRepos(ctx, client, org)
 		if err != nil {
 			logf("SKIP %s — could not list repos: %v", org, err)
@@ -118,28 +151,68 @@ func run(outDir string) error {
 		for _, repo := range repos {
 			collabs, err := listPushCollaborators(ctx, client, org, repo)
 			if err != nil {
-				logf("SKIP %s/%s — %v", org, repo, err)
-				continue
-			}
-			if len(collabs) == 0 {
-				continue
-			}
-			for _, c := range collabs {
-				writers = append(writers, Writer{
-					Login:      c,
-					Source:     org + "/" + repo,
-					AccessType: "direct_collaborator",
+				logf("SKIP %s/%s — collaborators: %v", org, repo, err)
+			} else if len(collabs) > 0 {
+				for _, c := range collabs {
+					writers = append(writers, Writer{
+						Login:      c,
+						Source:     org + "/" + repo,
+						AccessType: "direct_collaborator",
+					})
+				}
+				manifest = append(manifest, ManifestEntry{
+					Org:       org,
+					Repo:      repo,
+					Type:      "direct_collaborators",
+					Count:     len(collabs),
+					FetchedAt: time.Now().UTC().Format(time.RFC3339),
 				})
+				logf("OK   %s/%s — %d direct collaborators with push", org, repo, len(collabs))
 			}
-			manifest = append(manifest, ManifestEntry{
-				Org:       org,
-				Repo:      repo,
-				Type:      "direct_collaborators",
-				Count:     len(collabs),
-				FetchedAt: time.Now().UTC().Format(time.RFC3339),
-			})
-			logf("OK   %s/%s — %d direct collaborators with push", org, repo, len(collabs))
+
+			ms, found, err := fetchMaintainers(ctx, client, org, repo)
+			if err != nil {
+				logf("SKIP %s/%s — maintainers: %v", org, repo, err)
+			} else if found {
+				maintainers = append(maintainers, ms...)
+				manifest = append(manifest, ManifestEntry{
+					Org:       org,
+					Repo:      repo,
+					Type:      "maintainers_file",
+					Count:     len(ms),
+					FetchedAt: time.Now().UTC().Format(time.RFC3339),
+				})
+				logf("OK   %s/%s — %d maintainers parsed", org, repo, len(ms))
+			}
 		}
+	}
+
+	// Classify maintainers against the write-access set (matched by handle,
+	// case-insensitively). Matched entries enrich existing voters with
+	// name/email; unmatched entries (or those with no handle) are reported
+	// separately and do not become voters. The email->login mapping resolves
+	// the handle first, fixing entries listed by name+email only.
+	loginByLower := make(map[string]string, len(writers))
+	for _, w := range writers {
+		loginByLower[strings.ToLower(w.Login)] = w.Login
+	}
+	var noAccess []Maintainer
+	for _, m := range maintainers {
+		if id, ok := emailToLogin[strings.ToLower(m.Email)]; ok && m.Email != "" {
+			m.Handle = id
+		}
+		canon, ok := loginByLower[strings.ToLower(m.Handle)]
+		if m.Handle != "" && ok {
+			writers = append(writers, Writer{
+				Login:      canon,
+				Source:     m.Org + "/" + m.Repo,
+				AccessType: "maintainer",
+				Name:       m.Name,
+				Email:      m.Email,
+			})
+			continue
+		}
+		noAccess = append(noAccess, m)
 	}
 
 	// Write manifest.
@@ -151,9 +224,9 @@ func run(outDir string) error {
 	rawPath := filepath.Join(outDir, "write-access-raw.csv")
 	rawRows := make([][]string, len(writers))
 	for i, wr := range writers {
-		rawRows[i] = []string{wr.Login, wr.Source, wr.AccessType}
+		rawRows[i] = []string{wr.Login, wr.Source, wr.AccessType, wr.Name, wr.Email}
 	}
-	if err := writeCSV(rawPath, generatedAt, []string{"login", "source", "access_type"}, rawRows); err != nil {
+	if err := writeCSV(rawPath, generatedAt, []string{"login", "source", "access_type", "name", "email"}, rawRows); err != nil {
 		return fmt.Errorf("write raw csv: %w", err)
 	}
 
@@ -162,17 +235,31 @@ func run(outDir string) error {
 	finalPath := filepath.Join(outDir, "write-access.csv")
 	dedupRows := make([][]string, len(dedup))
 	for i, e := range dedup {
-		dedupRows[i] = []string{e.Login, strings.Join(e.Sources, ";"), strings.Join(e.AccessTypes, ";")}
+		dedupRows[i] = []string{
+			e.Login,
+			strings.Join(e.Sources, ";"),
+			strings.Join(e.AccessTypes, ";"),
+			strings.Join(e.Names, ";"),
+			strings.Join(e.Emails, ";"),
+		}
 	}
-	if err := writeCSV(finalPath, generatedAt, []string{"login", "sources", "access_types"}, dedupRows); err != nil {
+	if err := writeCSV(finalPath, generatedAt, []string{"login", "sources", "access_types", "name", "email"}, dedupRows); err != nil {
 		return fmt.Errorf("write final csv: %w", err)
 	}
 
+	// Write maintainers that are not in the write-access set.
+	noAccessPath := filepath.Join(outDir, "maintainers-without-write-access.csv")
+	noAccessRows := dedupMaintainers(noAccess)
+	if err := writeCSV(noAccessPath, generatedAt, []string{"name", "email", "github_handle", "repos"}, noAccessRows); err != nil {
+		return fmt.Errorf("write maintainers-without-write-access csv: %w", err)
+	}
+
 	logf("Done.")
-	logf("  Generated at : %s", generatedAt)
-	logf("  Raw entries  : %d -> %s", len(writers), rawPath)
-	logf("  Deduplicated : %d -> %s", len(dedup), finalPath)
-	logf("  Manifest     : %s", filepath.Join(outDir, "manifest.json"))
+	logf("  Generated at      : %s", generatedAt)
+	logf("  Raw entries       : %d -> %s", len(writers), rawPath)
+	logf("  Deduplicated      : %d -> %s", len(dedup), finalPath)
+	logf("  Maintainers w/o WA : %d -> %s", len(noAccessRows), noAccessPath)
+	logf("  Manifest          : %s", filepath.Join(outDir, "manifest.json"))
 
 	return nil
 }
@@ -186,6 +273,43 @@ func resolveToken() (string, error) {
 		return "", errors.New("no GITHUB_TOKEN env var and `gh auth token` failed; run `gh auth login` or set GITHUB_TOKEN")
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// loadEmailMapping reads an email->GitHub-login mapping from a CSV file with
+// "email,github_id" rows ('#' comment lines are ignored). A missing file is not
+// an error: it returns an empty map. Emails are lower-cased for matching.
+func loadEmailMapping(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logf("mapping file %s not found; continuing without it", path)
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	r.Comment = '#'
+	r.FieldsPerRecord = -1
+	rows, err := r.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]string, len(rows))
+	for _, row := range rows {
+		if len(row) < 2 {
+			continue
+		}
+		email := strings.ToLower(strings.TrimSpace(row[0]))
+		id := strings.TrimSpace(row[1])
+		if email == "" || id == "" || strings.EqualFold(email, "email") {
+			continue
+		}
+		m[email] = id
+	}
+	return m, nil
 }
 
 func listOrgMembers(ctx context.Context, client *github.Client, org string) ([]string, error) {
@@ -257,11 +381,177 @@ func listPushCollaborators(ctx context.Context, client *github.Client, org, repo
 	return all, nil
 }
 
+// maintainerFileNames are the root paths we look for, in priority order.
+var maintainerFileNames = []string{"MAINTAINERS.md", "MAINTAINER.md"}
+
+// fetchMaintainers fetches and parses a repo's root MAINTAINERS file. found is
+// false (with nil error) when no such file exists.
+func fetchMaintainers(ctx context.Context, client *github.Client, org, repo string) (entries []Maintainer, found bool, err error) {
+	for _, name := range maintainerFileNames {
+		fc, _, resp, err := client.Repositories.GetContents(ctx, org, repo, name, nil)
+		if err != nil {
+			if resp != nil && resp.StatusCode == 404 {
+				continue
+			}
+			return nil, false, err
+		}
+		content, err := fc.GetContent()
+		if err != nil {
+			return nil, false, err
+		}
+		parsed := parseMaintainers(content)
+		for i := range parsed {
+			parsed[i].Org = org
+			parsed[i].Repo = repo
+		}
+		return parsed, true, nil
+	}
+	return nil, false, nil
+}
+
+var (
+	emailRE  = regexp.MustCompile(`[\w.+%-]+@[\w-]+\.[\w.-]+`)
+	handleRE = regexp.MustCompile(`@([A-Za-z0-9-]+)`)
+	// githubURLRE captures the handle from a GitHub profile link, e.g.
+	// "[Ben Reedy](https://github.com/breed808)". The trailing delimiter keeps
+	// it from matching repo links like "github.com/org/repo/blob/…".
+	githubURLRE = regexp.MustCompile(`github\.com/([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(?:[)>?#\s]|$)`)
+	// mdLinkRE matches a markdown link; replacing with $1 keeps the link text.
+	mdLinkRE = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
+	// parenHandleRE matches a lone parenthesised token used as a handle, e.g.
+	// "(breed808)". Excludes anything containing @ or . so emails don't match.
+	parenHandleRE = regexp.MustCompile(`\(([A-Za-z0-9][A-Za-z0-9-]*)\)`)
+	// listMarkerRE strips leading bullet markers and an optional `component`:
+	// prefix, e.g. "* `tsdb`: ".
+	listMarkerRE = regexp.MustCompile("^[\\s>]*[*•-]?\\s*(?:`[^`]*`\\s*:?\\s*)*")
+	alumniRE     = regexp.MustCompile(`(?i)alumni|emeritus|former|past|previous|inactive|retired`)
+)
+
+// parseMaintainers extracts maintainer entries from a MAINTAINERS file. It is
+// deliberately lenient and best-effort: the ecosystem uses several formats
+// (`Name <email> @handle`, `Name (email / @handle)`, `Name (handle) - email`,
+// component-scoped and multi-maintainer lines). Prose intro lines may parse
+// imperfectly, but such people are typically org members (hence voters) anyway,
+// so only their name/email enrichment is affected.
+func parseMaintainers(content string) []Maintainer {
+	var out []Maintainer
+	skip := false // true while inside an alumni/former-maintainer section.
+
+	for _, rawLine := range strings.Split(content, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			continue
+		}
+
+		if heading, ok := sectionHeading(line); ok {
+			skip = alumniRE.MatchString(heading)
+			continue
+		}
+		if skip {
+			continue
+		}
+
+		body := listMarkerRE.ReplaceAllString(line, "")
+		// Names never contain commas, so commas separate maintainers on a line.
+		for _, chunk := range strings.Split(body, ",") {
+			if m, ok := parseMaintainerChunk(chunk); ok {
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
+// sectionHeading returns the heading text if line looks like a section heading
+// (a markdown "#" heading, a wholly-bold line, or a short colon-terminated
+// label with no email), so callers can detect alumni sections.
+func sectionHeading(line string) (string, bool) {
+	switch {
+	case strings.HasPrefix(line, "#"):
+		return strings.TrimLeft(line, "# "), true
+	case strings.HasPrefix(line, "**") && strings.HasSuffix(line, "**"):
+		return strings.Trim(line, "*: "), true
+	case strings.HasPrefix(line, "__") && strings.HasSuffix(line, "__"):
+		return strings.Trim(line, "_: "), true
+	case strings.HasSuffix(line, ":") && !emailRE.MatchString(line) && !strings.ContainsAny(line, "*-•"):
+		return strings.TrimRight(line, ": "), true
+	case isPlainHeading(line):
+		// A short capitalised line with no contact info, e.g. a bare "Alumni".
+		return line, true
+	}
+	return "", false
+}
+
+// isPlainHeading reports whether line is a short, capitalised label carrying no
+// maintainer contact info (email, handle, or profile link) — i.e. a section
+// header such as "Alumni" or "Maintainers in alphabetical order".
+func isPlainHeading(line string) bool {
+	r := []rune(line)
+	if len(r) == 0 || !unicode.IsUpper(r[0]) {
+		return false
+	}
+	if emailRE.MatchString(line) || strings.Contains(line, "@") ||
+		strings.Contains(line, "](") || strings.Contains(line, "github.com") {
+		return false
+	}
+	return len(strings.Fields(line)) <= 4
+}
+
+// parseMaintainerChunk parses a single maintainer from one comma-delimited chunk.
+func parseMaintainerChunk(chunk string) (Maintainer, bool) {
+	var m Maintainer
+
+	if loc := emailRE.FindStringIndex(chunk); loc != nil {
+		m.Email = chunk[loc[0]:loc[1]]
+	}
+	// Strip emails first so the "@" in an address isn't mistaken for a handle.
+	noEmail := emailRE.ReplaceAllString(chunk, " ")
+	switch {
+	case handleRE.MatchString(noEmail):
+		m.Handle = handleRE.FindStringSubmatch(noEmail)[1]
+	case githubURLRE.MatchString(chunk):
+		// Markdown profile link, e.g. "[Name](https://github.com/handle)".
+		m.Handle = githubURLRE.FindStringSubmatch(chunk)[1]
+	case m.Email != "" && parenHandleRE.MatchString(noEmail):
+		// A bare "(token)" is only treated as a handle alongside an email
+		// (e.g. "Name (breed808) - email"); otherwise prose like
+		// "maintainer(s)" would yield bogus handles.
+		m.Handle = parenHandleRE.FindStringSubmatch(noEmail)[1]
+	}
+
+	// Name is the leading text before the first email/handle/delimiter. Collapse
+	// markdown links to their text ("[Ben Reedy](url)" -> "Ben Reedy"), then cut
+	// at the email first so its local part isn't kept when it directly follows
+	// the name with no bracket (e.g. "Amy Super amy.super@grafana.com").
+	name := mdLinkRE.ReplaceAllString(chunk, "$1")
+	if loc := emailRE.FindStringIndex(name); loc != nil {
+		name = name[:loc[0]]
+	}
+	for _, sep := range []string{"<", "(", "@"} {
+		if i := strings.Index(name, sep); i >= 0 {
+			name = name[:i]
+		}
+	}
+	// Drop any leading "label:" prose left over from component-scoped lines
+	// (e.g. "`Makefile` and related build configuration: Simon Pasquier").
+	if i := strings.LastIndex(name, ":"); i >= 0 {
+		name = name[i+1:]
+	}
+	m.Name = strings.Trim(name, " \t/-:[]")
+
+	if m.Email == "" && m.Handle == "" {
+		return Maintainer{}, false
+	}
+	return m, true
+}
+
 // DedupEntry is one merged voter row.
 type DedupEntry struct {
 	Login       string
 	Sources     []string
 	AccessTypes []string
+	Names       []string
+	Emails      []string
 }
 
 func deduplicate(writers []Writer) []DedupEntry {
@@ -277,6 +567,8 @@ func deduplicate(writers []Writer) []DedupEntry {
 		}
 		e.Sources = append(e.Sources, w.Source)
 		e.AccessTypes = append(e.AccessTypes, w.AccessType)
+		e.Names = appendUnique(e.Names, w.Name)
+		e.Emails = appendUnique(e.Emails, w.Email)
 	}
 
 	out := make([]DedupEntry, 0, len(byLogin))
@@ -287,6 +579,74 @@ func deduplicate(writers []Writer) []DedupEntry {
 		return strings.ToLower(out[i].Login) < strings.ToLower(out[j].Login)
 	})
 	return out
+}
+
+// appendUnique appends v to s if v is non-empty and not already present.
+func appendUnique(s []string, v string) []string {
+	if v == "" {
+		return s
+	}
+	for _, e := range s {
+		if e == v {
+			return s
+		}
+	}
+	return append(s, v)
+}
+
+// dedupMaintainers merges maintainer entries that refer to the same person
+// (keyed by handle, else email, else name — case-insensitively) and returns
+// CSV rows of [name, email, github_handle, repos], sorted by name.
+func dedupMaintainers(ms []Maintainer) [][]string {
+	type agg struct {
+		name, email, handle string
+		repos               []string
+	}
+	byKey := make(map[string]*agg)
+	for _, m := range ms {
+		key := strings.ToLower(firstNonEmpty(m.Handle, m.Email, m.Name))
+		if key == "" {
+			continue
+		}
+		a, ok := byKey[key]
+		if !ok {
+			a = &agg{name: m.Name, email: m.Email, handle: m.Handle}
+			byKey[key] = a
+		}
+		if a.name == "" {
+			a.name = m.Name
+		}
+		if a.email == "" {
+			a.email = m.Email
+		}
+		if a.handle == "" {
+			a.handle = m.Handle
+		}
+		a.repos = appendUnique(a.repos, m.Org+"/"+m.Repo)
+	}
+
+	rows := make([][]string, 0, len(byKey))
+	for _, a := range byKey {
+		sort.Strings(a.repos)
+		rows = append(rows, []string{a.name, a.email, a.handle, strings.Join(a.repos, ";")})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if li, lj := strings.ToLower(rows[i][0]), strings.ToLower(rows[j][0]); li != lj {
+			return li < lj
+		}
+		return rows[i][1] < rows[j][1]
+	})
+	return rows
+}
+
+// firstNonEmpty returns the first non-empty string among its arguments.
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func writeManifest(path string, entries []ManifestEntry) (err error) {
@@ -339,4 +699,3 @@ func writeCSV(path, generatedAt string, header []string, rows [][]string) (err e
 func logf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "[%s] %s\n", time.Now().UTC().Format(time.RFC3339), fmt.Sprintf(format, args...))
 }
-

--- a/elections/2026/voters-list/main_test.go
+++ b/elections/2026/voters-list/main_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseMaintainers(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []Maintainer
+	}{
+		{
+			name:    "angle-bracket email and handle",
+			content: "* Ben Kochie <superq@gmail.com> @SuperQ\n* Johannes 'fish' Ziemke <github@freigeist.org> @discordianfish\n",
+			want: []Maintainer{
+				{Name: "Ben Kochie", Email: "superq@gmail.com", Handle: "SuperQ"},
+				{Name: "Johannes 'fish' Ziemke", Email: "github@freigeist.org", Handle: "discordianfish"},
+			},
+		},
+		{
+			name:    "email and handle in parens",
+			content: "- André Bauer (monotek23@gmail.com / @monotek)\n- Scott Rigby (scott@r6by.com / @scottrigby)\n",
+			want: []Maintainer{
+				{Name: "André Bauer", Email: "monotek23@gmail.com", Handle: "monotek"},
+				{Name: "Scott Rigby", Email: "scott@r6by.com", Handle: "scottrigby"},
+			},
+		},
+		{
+			name:    "handle in parens without @, email after dash",
+			content: "- Ben Reedy (breed808) - breed808@breed808.com\n- Jan-Otto Kröpke (jkroepke) - github@jkroepke.de\n",
+			want: []Maintainer{
+				{Name: "Ben Reedy", Email: "breed808@breed808.com", Handle: "breed808"},
+				{Name: "Jan-Otto Kröpke", Email: "github@jkroepke.de", Handle: "jkroepke"},
+			},
+		},
+		{
+			name:    "no email",
+			content: "* Steve Durrheimer <s.durrheimer@gmail.com>\n",
+			want: []Maintainer{
+				{Name: "Steve Durrheimer", Email: "s.durrheimer@gmail.com"},
+			},
+		},
+		{
+			name:    "component prefix and multiple maintainers per line",
+			content: "* `tsdb`: Ganesh Vernekar (<ganesh@grafana.com> / @codesome), Bartłomiej Płotka (<bwplotka@gmail.com> / @bwplotka)\n",
+			want: []Maintainer{
+				{Name: "Ganesh Vernekar", Email: "ganesh@grafana.com", Handle: "codesome"},
+				{Name: "Bartłomiej Płotka", Email: "bwplotka@gmail.com", Handle: "bwplotka"},
+			},
+		},
+		{
+			name:    "email directly after name, handle in parens",
+			content: "* Amy Super amy.super@grafana.com (@amy-super)\n",
+			want: []Maintainer{
+				{Name: "Amy Super", Email: "amy.super@grafana.com", Handle: "amy-super"},
+			},
+		},
+		{
+			name:    "handle without slash inside parens",
+			content: "* `module`: Augustin Husson (<husson.augustin@gmail.com> @nexucis)\n",
+			want: []Maintainer{
+				{Name: "Augustin Husson", Email: "husson.augustin@gmail.com", Handle: "nexucis"},
+			},
+		},
+		{
+			name: "alumni section is skipped",
+			content: "**Current Maintainers:**\n" +
+				"- Ben Reedy (breed808) - breed808@breed808.com\n\n" +
+				"**Alumni Contributors:**\n" +
+				"- Brian Brazil (brian-brazil)\n" +
+				"- Calle Pettersson (carlpett)\n",
+			want: []Maintainer{
+				{Name: "Ben Reedy", Email: "breed808@breed808.com", Handle: "breed808"},
+			},
+		},
+		{
+			name: "markdown profile links, plain-text alumni heading skipped",
+			content: "Maintainers in alphabetical order\n\n" +
+				"* [Ben Reedy](https://github.com/breed808) - breed808@breed808.com\n" +
+				"* [Jan-Otto Kröpke](https://github.com/jkroepke) - github@jkroepke.de\n\n" +
+				"Alumni\n\n" +
+				"* [Brian Brazil](https://github.com/brian-brazil)\n",
+			want: []Maintainer{
+				{Name: "Ben Reedy", Email: "breed808@breed808.com", Handle: "breed808"},
+				{Name: "Jan-Otto Kröpke", Email: "github@jkroepke.de", Handle: "jkroepke"},
+			},
+		},
+		{
+			name: "markdown link to another repo's file is not a maintainer",
+			content: "to the maintainers specified in Alertmanager's\n" +
+				"[MAINTAINERS.md](https://github.com/prometheus/alertmanager/blob/main/MAINTAINERS.md)\n" +
+				"file for documentation about the Alertmanager.\n",
+			want: nil,
+		},
+		{
+			name: "markdown heading sections are not parsed as maintainers",
+			content: "# Maintainers\n\n" +
+				"* Julien Pivotto <roidelapluie@prometheus.io> @roidelapluie\n",
+			want: []Maintainer{
+				{Name: "Julien Pivotto", Email: "roidelapluie@prometheus.io", Handle: "roidelapluie"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseMaintainers(tt.content)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseMaintainers() mismatch\n got: %#v\nwant: %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadEmailMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "email-to-github.csv")
+	content := "# a comment\n" +
+		"email,github_id\n" +
+		"superq@gmail.com,SuperQ\n" +
+		"  Julius.Volz@gmail.com , juliusv \n" + // whitespace + mixed case
+		"\n" +
+		"# trailing comment\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadEmailMapping(path)
+	if err != nil {
+		t.Fatalf("loadEmailMapping: %v", err)
+	}
+	want := map[string]string{
+		"superq@gmail.com":      "SuperQ",
+		"julius.volz@gmail.com": "juliusv",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadEmailMapping() = %#v, want %#v", got, want)
+	}
+
+	// A missing file is not an error.
+	got, err = loadEmailMapping(filepath.Join(dir, "does-not-exist.csv"))
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("missing file should yield empty map, got %#v", got)
+	}
+}

--- a/elections/2026/voters-list/maintainers-without-write-access.csv
+++ b/elections/2026/voters-list/maintainers-without-write-access.csv
@@ -1,0 +1,9 @@
+# Generated at: 2026-05-26T14:27:04Z
+name,email,github_handle,repos
+Björn Rabenstein,beorn@grafana.com,beorn7,prometheus/prometheus-ghsa-p54f-935g-x7j2
+Chris Sinjakli,chris@sinjakli.co.uk,,prometheus/client_ruby
+Matthias Rampke,matthias@prometheus.io,,prometheus-community/rsyslog_exporter;prometheus/graphite_exporter;prometheus/influxdb_exporter
+maxime1907,19607336+maxime1907@users.noreply.github.com,maxime1907,prometheus-community/helm-charts
+Robert Fratto,robert.fratto@grafana.com,rfratto,prometheus/prometheus-ghsa-p54f-935g-x7j2
+Steve Durrheimer,s.durrheimer@gmail.com,,prometheus/busybox;prometheus/golang-builder
+Tom Braack,me@shorez.de,sh0rez,prometheus-community/prometheus;prometheus/prometheus

--- a/elections/2026/voters-list/manifest.json
+++ b/elections/2026/voters-list/manifest.json
@@ -2,378 +2,832 @@
   {
     "org": "prometheus",
     "type": "org_members",
-    "count": 71,
-    "fetched_at": "2026-04-30T08:47:28Z"
+    "count": 70,
+    "fetched_at": "2026-05-26T14:27:04Z"
   },
   {
     "org": "prometheus-community",
     "type": "org_members",
-    "count": 119,
-    "fetched_at": "2026-04-30T08:47:29Z"
+    "count": 118,
+    "fetched_at": "2026-05-26T14:27:05Z"
   },
   {
     "org": "prometheus",
     "repo": "prometheus",
     "type": "direct_collaborators",
     "count": 6,
-    "fetched_at": "2026-04-30T08:47:30Z"
+    "fetched_at": "2026-05-26T14:27:06Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "prometheus",
+    "type": "maintainers_file",
+    "count": 34,
+    "fetched_at": "2026-05-26T14:27:06Z"
   },
   {
     "org": "prometheus",
     "repo": "client_golang",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:30Z"
+    "fetched_at": "2026-05-26T14:27:06Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "client_golang",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:07Z"
   },
   {
     "org": "prometheus",
     "repo": "client_java",
     "type": "direct_collaborators",
     "count": 5,
-    "fetched_at": "2026-04-30T08:47:31Z"
+    "fetched_at": "2026-05-26T14:27:07Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "client_java",
+    "type": "maintainers_file",
+    "count": 4,
+    "fetched_at": "2026-05-26T14:27:07Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "node_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:08Z"
   },
   {
     "org": "prometheus",
     "repo": "client_ruby",
     "type": "direct_collaborators",
     "count": 2,
-    "fetched_at": "2026-04-30T08:47:31Z"
+    "fetched_at": "2026-05-26T14:27:08Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "client_ruby",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:08Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "client_model",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:09Z"
   },
   {
     "org": "prometheus",
     "repo": "statsd_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:32Z"
+    "fetched_at": "2026-05-26T14:27:09Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "statsd_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:10Z"
   },
   {
     "org": "prometheus",
     "repo": "alertmanager",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:32Z"
+    "fetched_at": "2026-05-26T14:27:10Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "alertmanager",
+    "type": "maintainers_file",
+    "count": 8,
+    "fetched_at": "2026-05-26T14:27:10Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "pushgateway",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:11Z"
   },
   {
     "org": "prometheus",
     "repo": "jmx_exporter",
     "type": "direct_collaborators",
     "count": 4,
-    "fetched_at": "2026-04-30T08:47:33Z"
+    "fetched_at": "2026-05-26T14:27:11Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "jmx_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:12Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "prom2json",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:12Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "docs",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:13Z"
   },
   {
     "org": "prometheus",
     "repo": "procfs",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:34Z"
+    "fetched_at": "2026-05-26T14:27:13Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "procfs",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:14Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "cloudwatch_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:14Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "collectd_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:15Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "client_python",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:15Z"
   },
   {
     "org": "prometheus",
     "repo": "snmp_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:35Z"
+    "fetched_at": "2026-05-26T14:27:15Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "snmp_exporter",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:16Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "mysqld_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:16Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "consul_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:17Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "graphite_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:18Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "common",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:18Z"
   },
   {
     "org": "prometheus",
     "repo": "blackbox_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:37Z"
+    "fetched_at": "2026-05-26T14:27:18Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "blackbox_exporter",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:19Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "busybox",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:19Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "golang-builder",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:20Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "influxdb_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:21Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "promu",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:21Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "memcached_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:22Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "test-infra",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:22Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "promcon",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:23Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "OpenMetrics",
+    "type": "maintainers_file",
+    "count": 0,
+    "fetched_at": "2026-05-26T14:27:24Z"
   },
   {
     "org": "prometheus",
     "repo": "prometheus_api_client_ruby",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:40Z"
+    "fetched_at": "2026-05-26T14:27:24Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "prometheus_api_client_ruby",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:24Z"
   },
   {
     "org": "prometheus",
     "repo": "talks",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:40Z"
+    "fetched_at": "2026-05-26T14:27:24Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "talks",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:25Z"
   },
   {
     "org": "prometheus",
     "repo": "demo-site",
     "type": "direct_collaborators",
     "count": 2,
-    "fetched_at": "2026-04-30T08:47:41Z"
+    "fetched_at": "2026-05-26T14:27:25Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "demo-site",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:26Z"
   },
   {
     "org": "prometheus",
     "repo": "circleci",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:41Z"
+    "fetched_at": "2026-05-26T14:27:26Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "circleci",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:26Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "exporter-toolkit",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:27Z"
   },
   {
     "org": "prometheus",
     "repo": "client_rust",
     "type": "direct_collaborators",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:27Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "client_rust",
+    "type": "maintainers_file",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:42Z"
+    "fetched_at": "2026-05-26T14:27:28Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "snmp_exporter_mibs",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:28Z"
   },
   {
     "org": "prometheus",
     "repo": "compliance",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:43Z"
+    "fetched_at": "2026-05-26T14:27:29Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "compliance",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:29Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "promlens",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:30Z"
   },
   {
     "org": "prometheus",
     "repo": "proposals",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:44Z"
+    "fetched_at": "2026-05-26T14:27:31Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "prometheus-ghsa-p54f-935g-x7j2",
+    "type": "maintainers_file",
+    "count": 15,
+    "fetched_at": "2026-05-26T14:27:32Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "sigv4",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:34Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "otlptranslator",
+    "type": "maintainers_file",
+    "count": 4,
+    "fetched_at": "2026-05-26T14:27:35Z"
   },
   {
     "org": "prometheus",
     "repo": "test-sd-ownership",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:46Z"
+    "fetched_at": "2026-05-26T14:27:35Z"
+  },
+  {
+    "org": "prometheus",
+    "repo": "common-ghsa-qmwc-fc99-jm3h",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:41Z"
   },
   {
     "org": "prometheus-community",
     "repo": "elasticsearch_exporter",
     "type": "direct_collaborators",
     "count": 5,
-    "fetched_at": "2026-04-30T08:47:49Z"
+    "fetched_at": "2026-05-26T14:27:42Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "elasticsearch_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:43Z"
   },
   {
     "org": "prometheus-community",
     "repo": "postgres_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:49Z"
+    "fetched_at": "2026-05-26T14:27:43Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "postgres_exporter",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:44Z"
   },
   {
     "org": "prometheus-community",
     "repo": "bind_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:49Z"
+    "fetched_at": "2026-05-26T14:27:44Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "bind_exporter",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:44Z"
   },
   {
     "org": "prometheus-community",
     "repo": "json_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:50Z"
+    "fetched_at": "2026-05-26T14:27:45Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "json_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:45Z"
   },
   {
     "org": "prometheus-community",
     "repo": "windows_exporter",
     "type": "direct_collaborators",
     "count": 3,
-    "fetched_at": "2026-04-30T08:47:50Z"
+    "fetched_at": "2026-05-26T14:27:45Z"
   },
   {
     "org": "prometheus-community",
-    "repo": "kitefactory",
-    "type": "direct_collaborators",
-    "count": 1,
-    "fetched_at": "2026-04-30T08:47:51Z"
+    "repo": "windows_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:45Z"
   },
   {
     "org": "prometheus-community",
     "repo": "stackdriver_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:51Z"
+    "fetched_at": "2026-05-26T14:27:46Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "stackdriver_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:46Z"
   },
   {
     "org": "prometheus-community",
     "repo": "PushProx",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:51Z"
+    "fetched_at": "2026-05-26T14:27:46Z"
   },
   {
     "org": "prometheus-community",
     "repo": "yet-another-cloudwatch-exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:52Z"
+    "fetched_at": "2026-05-26T14:27:48Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "yet-another-cloudwatch-exporter",
+    "type": "maintainers_file",
+    "count": 4,
+    "fetched_at": "2026-05-26T14:27:48Z"
   },
   {
     "org": "prometheus-community",
     "repo": "pgbouncer_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:52Z"
+    "fetched_at": "2026-05-26T14:27:48Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "pgbouncer_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:49Z"
   },
   {
     "org": "prometheus-community",
     "repo": "ipmi_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:52Z"
+    "fetched_at": "2026-05-26T14:27:49Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "ipmi_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:49Z"
   },
   {
     "org": "prometheus-community",
     "repo": "avalanche",
     "type": "direct_collaborators",
     "count": 2,
-    "fetched_at": "2026-04-30T08:47:53Z"
+    "fetched_at": "2026-05-26T14:27:50Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "avalanche",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:50Z"
   },
   {
     "org": "prometheus-community",
     "repo": "prom-label-proxy",
     "type": "direct_collaborators",
     "count": 3,
-    "fetched_at": "2026-04-30T08:47:53Z"
+    "fetched_at": "2026-05-26T14:27:50Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "prom-label-proxy",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:51Z"
   },
   {
     "org": "prometheus-community",
     "repo": "prometheus-playground",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:53Z"
+    "fetched_at": "2026-05-26T14:27:51Z"
   },
   {
     "org": "prometheus-community",
     "repo": "snmp",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:54Z"
+    "fetched_at": "2026-05-26T14:27:52Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "snmp",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:52Z"
   },
   {
     "org": "prometheus-community",
     "repo": "community",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:54Z"
+    "fetched_at": "2026-05-26T14:27:53Z"
   },
   {
     "org": "prometheus-community",
     "repo": "node-exporter-textfile-collector-scripts",
     "type": "direct_collaborators",
     "count": 2,
-    "fetched_at": "2026-04-30T08:47:55Z"
+    "fetched_at": "2026-05-26T14:27:54Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "node-exporter-textfile-collector-scripts",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:55Z"
   },
   {
     "org": "prometheus-community",
     "repo": "smartctl_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:55Z"
+    "fetched_at": "2026-05-26T14:27:55Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "smartctl_exporter",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:27:55Z"
   },
   {
     "org": "prometheus-community",
     "repo": "prometheus",
     "type": "direct_collaborators",
     "count": 2,
-    "fetched_at": "2026-04-30T08:47:55Z"
+    "fetched_at": "2026-05-26T14:27:55Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "prometheus",
+    "type": "maintainers_file",
+    "count": 33,
+    "fetched_at": "2026-05-26T14:27:56Z"
   },
   {
     "org": "prometheus-community",
     "repo": "promql-langserver",
     "type": "direct_collaborators",
     "count": 3,
-    "fetched_at": "2026-04-30T08:47:56Z"
+    "fetched_at": "2026-05-26T14:27:56Z"
   },
   {
     "org": "prometheus-community",
     "repo": "vscode-promql",
     "type": "direct_collaborators",
     "count": 5,
-    "fetched_at": "2026-04-30T08:47:56Z"
+    "fetched_at": "2026-05-26T14:27:57Z"
   },
   {
     "org": "prometheus-community",
     "repo": "rsyslog_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:56Z"
+    "fetched_at": "2026-05-26T14:27:58Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "rsyslog_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:58Z"
   },
   {
     "org": "prometheus-community",
     "repo": "monaco-promql",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:57Z"
+    "fetched_at": "2026-05-26T14:27:58Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "monaco-promql",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:27:59Z"
   },
   {
     "org": "prometheus-community",
     "repo": "fortigate_exporter",
     "type": "direct_collaborators",
     "count": 3,
-    "fetched_at": "2026-04-30T08:47:57Z"
+    "fetched_at": "2026-05-26T14:27:59Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "fortigate_exporter",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:27:59Z"
   },
   {
     "org": "prometheus-community",
     "repo": "sublimelsp-promql",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:57Z"
+    "fetched_at": "2026-05-26T14:28:00Z"
   },
   {
     "org": "prometheus-community",
     "repo": "helm-charts",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:58Z"
+    "fetched_at": "2026-05-26T14:28:00Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "helm-charts",
+    "type": "maintainers_file",
+    "count": 101,
+    "fetched_at": "2026-05-26T14:28:01Z"
   },
   {
     "org": "prometheus-community",
     "repo": "ecs_exporter",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:58Z"
+    "fetched_at": "2026-05-26T14:28:01Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "pro-bing",
+    "type": "maintainers_file",
+    "count": 2,
+    "fetched_at": "2026-05-26T14:28:02Z"
   },
   {
     "org": "prometheus-community",
     "repo": "ansible",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:59Z"
+    "fetched_at": "2026-05-26T14:28:03Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "ansible",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:28:03Z"
   },
   {
     "org": "prometheus-community",
     "repo": "go-runit",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:47:59Z"
+    "fetched_at": "2026-05-26T14:28:03Z"
   },
   {
     "org": "prometheus-community",
     "repo": "ux-research",
     "type": "direct_collaborators",
     "count": 3,
-    "fetched_at": "2026-04-30T08:48:00Z"
+    "fetched_at": "2026-05-26T14:28:04Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "ux-research",
+    "type": "maintainers_file",
+    "count": 3,
+    "fetched_at": "2026-05-26T14:28:04Z"
   },
   {
     "org": "prometheus-community",
     "repo": "parquet-wg",
     "type": "direct_collaborators",
     "count": 2,
-    "fetched_at": "2026-04-30T08:48:00Z"
+    "fetched_at": "2026-05-26T14:28:05Z"
   },
   {
     "org": "prometheus-community",
     "repo": "parquet-common",
     "type": "direct_collaborators",
     "count": 6,
-    "fetched_at": "2026-04-30T08:48:00Z"
+    "fetched_at": "2026-05-26T14:28:05Z"
   },
   {
     "org": "prometheus-community",
     "repo": "highlightjs-promql",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:48:00Z"
+    "fetched_at": "2026-05-26T14:28:06Z"
+  },
+  {
+    "org": "prometheus-community",
+    "repo": "highlightjs-promql",
+    "type": "maintainers_file",
+    "count": 1,
+    "fetched_at": "2026-05-26T14:28:07Z"
   },
   {
     "org": "prometheus-community",
     "repo": "parmetheus",
     "type": "direct_collaborators",
     "count": 1,
-    "fetched_at": "2026-04-30T08:48:01Z"
+    "fetched_at": "2026-05-26T14:28:07Z"
   }
 ]
-

--- a/elections/2026/voters-list/write-access-raw.csv
+++ b/elections/2026/voters-list/write-access-raw.csv
@@ -1,286 +1,581 @@
-# Generated at: 2026-04-30T08:47:28Z
-login,source,access_type
-aknuds1,prometheus,org_member
-alexgreenbank,prometheus,org_member
-ArthurSens,prometheus,org_member
-bastischubert,prometheus,org_member
-bboreham,prometheus,org_member
-beorn7,prometheus,org_member
-bitfehler,prometheus,org_member
-brancz,prometheus,org_member
-breed808,prometheus,org_member
-bwplotka,prometheus,org_member
-caniszczyk,prometheus,org_member
-carlpett,prometheus,org_member
-carrieedwards,prometheus,org_member
-codesome,prometheus,org_member
-cristiangreco,prometheus,org_member
-csmarchbanks,prometheus,org_member
-cstyan,prometheus,org_member
-dashpole,prometheus,org_member
-dgl,prometheus,org_member
-dhoard,prometheus,org_member
-discordianfish,prometheus,org_member
-dmagliola,prometheus,org_member
-dswarbrick,prometheus,org_member
-electron0zero,prometheus,org_member
-fionaliao,prometheus,org_member
-fstab,prometheus,org_member
-gardar,prometheus,org_member
-gotjosh,prometheus,org_member
-gouthamve,prometheus,org_member
-grobie,prometheus,org_member
-grobinson-grafana,prometheus,org_member
-jan--f,prometheus,org_member
-jesusvazquez,prometheus,org_member
-jkroepke,prometheus,org_member
-juliusv,prometheus,org_member
-kakkoyun,prometheus,org_member
-krajorama,prometheus,org_member
-machine424,prometheus,org_member
-matthiasr,prometheus,org_member
-mem,prometheus,org_member
-metalmatze,prometheus,org_member
-mxinden,prometheus,org_member
-Nexucis,prometheus,org_member
-npazosmendez,prometheus,org_member
-paulfantom,prometheus,org_member
-pedro-stanaka,prometheus,org_member
-pgier,prometheus,org_member
-prombot,prometheus,org_member
-rajagopalanand,prometheus,org_member
-RichiH,prometheus,org_member
-roidelapluie,prometheus,org_member
-saswatamcode,prometheus,org_member
-siavashs,prometheus,org_member
-simonpasquier,prometheus,org_member
-Sinjo,prometheus,org_member
-SoloJacobs,prometheus,org_member
-Spaceman1701,prometheus,org_member
-SuperQ,prometheus,org_member
-sysadmind,prometheus,org_member
-thelinuxfoundation,prometheus,org_member
-TheMeier,prometheus,org_member
-thomaspeitz,prometheus,org_member
-tombrk,prometheus,org_member
-tomwilkie,prometheus,org_member
-ultrotter,prometheus,org_member
-vesari,prometheus,org_member
-w0rm,prometheus,org_member
-waltherlee,prometheus,org_member
-yaacov,prometheus,org_member
-ywwg,prometheus,org_member
-zeitlinger,prometheus,org_member
-acondrat,prometheus-community,org_member
-aleroyer,prometheus-community,org_member
-andrewgkew,prometheus-community,org_member
-andriikushch,prometheus-community,org_member
-arslanbekov,prometheus-community,org_member
-arthlr,prometheus-community,org_member
-ArthurSens,prometheus-community,org_member
-asherf,prometheus-community,org_member
-bastischubert,prometheus-community,org_member
-beorn7,prometheus-community,org_member
-bitfehler,prometheus-community,org_member
-bluecmd,prometheus-community,org_member
-brancz,prometheus-community,org_member
-breed808,prometheus-community,org_member
-bwplotka,prometheus-community,org_member
-caarlos0,prometheus-community,org_member
-caniszczyk,prometheus-community,org_member
-carlpett,prometheus-community,org_member
-celian-garcia,prometheus-community,org_member
-codesome,prometheus-community,org_member
-cristiangreco,prometheus-community,org_member
-csmarchbanks,prometheus-community,org_member
-cstaud,prometheus-community,org_member
-cstyan,prometheus-community,org_member
-dacamposol,prometheus-community,org_member
-derekmarcotte,prometheus-community,org_member
-desaintmartin,prometheus-community,org_member
-discordianfish,prometheus-community,org_member
-dongjiang1989,prometheus-community,org_member
-dotdc,prometheus-community,org_member
-DrFaust92,prometheus-community,org_member
-dswarbrick,prometheus-community,org_member
-erdii,prometheus-community,org_member
-fabxc,prometheus-community,org_member
-free,prometheus-community,org_member
-frodenas,prometheus-community,org_member
-gardar,prometheus-community,org_member
-geekodour,prometheus-community,org_member
-gianrubio,prometheus-community,org_member
-gkarthiks,prometheus-community,org_member
-GMartinez-Sisti,prometheus-community,org_member
-golgoth31,prometheus-community,org_member
-gouthamve,prometheus-community,org_member
-grobie,prometheus-community,org_member
-hectorj2f,prometheus-community,org_member
-iamabhishek-dubey,prometheus-community,org_member
-igaskin,prometheus-community,org_member
-JessicaGreben,prometheus-community,org_member
-jesusvazquez,prometheus-community,org_member
-jkroepke,prometheus-community,org_member
-Juanchimienti,prometheus-community,org_member
-juliusv,prometheus-community,org_member
-kawamuray,prometheus-community,org_member
-kfox1111,prometheus-community,org_member
-kgeckhart,prometheus-community,org_member
-lexfrei,prometheus-community,org_member
-lilic,prometheus-community,org_member
-lucperkins,prometheus-community,org_member
-marthjod,prometheus-community,org_member
-martinlindhe,prometheus-community,org_member
-matthiasr,prometheus-community,org_member
-MattiasGees,prometheus-community,org_member
-maximee-leroyy,prometheus-community,org_member
-maxwo,prometheus-community,org_member
-metalmatze,prometheus-community,org_member
-monotek,prometheus-community,org_member
-mrueg,prometheus-community,org_member
-mxinden,prometheus-community,org_member
-naseemkullah,prometheus-community,org_member
-nevill,prometheus-community,org_member
-Nexucis,prometheus-community,org_member
-NiceGuyIT,prometheus-community,org_member
-nlamirault,prometheus-community,org_member
-okgolove,prometheus-community,org_member
-openenergyprojects,prometheus-community,org_member
-paulfantom,prometheus-community,org_member
-povilasv,prometheus-community,org_member
-prombot,prometheus-community,org_member
-QuentinBisson,prometheus-community,org_member
-rakyll,prometheus-community,org_member
-rayram23,prometheus-community,org_member
-RichiH,prometheus-community,org_member
-roidelapluie,prometheus-community,org_member
-rpahli,prometheus-community,org_member
-rsicart,prometheus-community,org_member
-rsotnychenko,prometheus-community,org_member
-rustycl0ck,prometheus-community,org_member
-s-urbaniak,prometheus-community,org_member
-scDisorder,prometheus-community,org_member
-schmiddim,prometheus-community,org_member
-scottrigby,prometheus-community,org_member
-Sheridan,prometheus-community,org_member
-simonfrey,prometheus-community,org_member
-simonpasquier,prometheus-community,org_member
-slrtbtfs,prometheus-community,org_member
-squat,prometheus-community,org_member
-stanhu,prometheus-community,org_member
-steven-sheehy,prometheus-community,org_member
-stewartshea,prometheus-community,org_member
-stuartnelson3,prometheus-community,org_member
-SuperQ,prometheus-community,org_member
-svenmueller,prometheus-community,org_member
-sysadmind,prometheus-community,org_member
-tariq1890,prometheus-community,org_member
-thomaspeitz,prometheus-community,org_member
-timm088,prometheus-community,org_member
-tomwilkie,prometheus-community,org_member
-torstenwalter,prometheus-community,org_member
-tristanburgess,prometheus-community,org_member
-vesari,prometheus-community,org_member
-vsliouniaev,prometheus-community,org_member
-walker-tom,prometheus-community,org_member
-wilfriedroset,prometheus-community,org_member
-wrouesnel,prometheus-community,org_member
-xiu,prometheus-community,org_member
-Xtigyro,prometheus-community,org_member
-zanhsieh,prometheus-community,org_member
-zeritti,prometheus-community,org_member
-zwopir,prometheus-community,org_member
-remyleone,prometheus/prometheus,direct_collaborator
-apricote,prometheus/prometheus,direct_collaborator
-jooola,prometheus/prometheus,direct_collaborator
-matt-gp,prometheus/prometheus,direct_collaborator
-mrvarmazyar,prometheus/prometheus,direct_collaborator
-rexagod,prometheus/prometheus,direct_collaborator
-ArthurSens,prometheus/client_golang,direct_collaborator
-martincostello,prometheus/client_java,direct_collaborator
-zeitlinger,prometheus/client_java,direct_collaborator
-jaydeluca,prometheus/client_java,direct_collaborator
-dhoard,prometheus/client_java,direct_collaborator
-jack-berg,prometheus/client_java,direct_collaborator
-Sinjo,prometheus/client_ruby,direct_collaborator
-dmagliola,prometheus/client_ruby,direct_collaborator
-SuperQ,prometheus/statsd_exporter,direct_collaborator
-grobinson-grafana,prometheus/alertmanager,direct_collaborator
-fstab,prometheus/jmx_exporter,direct_collaborator
-zeitlinger,prometheus/jmx_exporter,direct_collaborator
-jaydeluca,prometheus/jmx_exporter,direct_collaborator
-dhoard,prometheus/jmx_exporter,direct_collaborator
-pgier,prometheus/procfs,direct_collaborator
-bastischubert,prometheus/snmp_exporter,direct_collaborator
-mem,prometheus/blackbox_exporter,direct_collaborator
-yaacov,prometheus/prometheus_api_client_ruby,direct_collaborator
-SuperQ,prometheus/talks,direct_collaborator
-gardar,prometheus/demo-site,direct_collaborator
-paulfantom,prometheus/demo-site,direct_collaborator
-simonpasquier,prometheus/circleci,direct_collaborator
-mxinden,prometheus/client_rust,direct_collaborator
-tomwilkie,prometheus/compliance,direct_collaborator
-bwplotka,prometheus/proposals,direct_collaborator
-ldufr,prometheus/test-sd-ownership,direct_collaborator
-metalmatze,prometheus-community/elasticsearch_exporter,direct_collaborator
-marthjod,prometheus-community/elasticsearch_exporter,direct_collaborator
-zwopir,prometheus-community/elasticsearch_exporter,direct_collaborator
-prombot,prometheus-community/elasticsearch_exporter,direct_collaborator
-simonfrey,prometheus-community/elasticsearch_exporter,direct_collaborator
-prombot,prometheus-community/postgres_exporter,direct_collaborator
-prombot,prometheus-community/bind_exporter,direct_collaborator
-prombot,prometheus-community/json_exporter,direct_collaborator
-martinlindhe,prometheus-community/windows_exporter,direct_collaborator
-carlpett,prometheus-community/windows_exporter,direct_collaborator
-prombot,prometheus-community/windows_exporter,direct_collaborator
-derekmarcotte,prometheus-community/kitefactory,direct_collaborator
-prombot,prometheus-community/stackdriver_exporter,direct_collaborator
-prombot,prometheus-community/PushProx,direct_collaborator
-prombot,prometheus-community/yet-another-cloudwatch-exporter,direct_collaborator
-prombot,prometheus-community/pgbouncer_exporter,direct_collaborator
-prombot,prometheus-community/ipmi_exporter,direct_collaborator
-prombot,prometheus-community/avalanche,direct_collaborator
-saswatamcode,prometheus-community/avalanche,direct_collaborator
-brancz,prometheus-community/prom-label-proxy,direct_collaborator
-prombot,prometheus-community/prom-label-proxy,direct_collaborator
-prom-label-proxy-bot,prometheus-community/prom-label-proxy,direct_collaborator
-lucperkins,prometheus-community/prometheus-playground,direct_collaborator
-prombot,prometheus-community/snmp,direct_collaborator
-povilasv,prometheus-community/community,direct_collaborator
-discordianfish,prometheus-community/node-exporter-textfile-collector-scripts,direct_collaborator
-prombot,prometheus-community/node-exporter-textfile-collector-scripts,direct_collaborator
-prombot,prometheus-community/smartctl_exporter,direct_collaborator
-nevill,prometheus-community/prometheus,direct_collaborator
-geekodour,prometheus-community/prometheus,direct_collaborator
-slrtbtfs,prometheus-community/promql-langserver,direct_collaborator
-prombot,prometheus-community/promql-langserver,direct_collaborator
-squat,prometheus-community/promql-langserver,direct_collaborator
-ant31,prometheus-community/vscode-promql,direct_collaborator
-simonpasquier,prometheus-community/vscode-promql,direct_collaborator
-slrtbtfs,prometheus-community/vscode-promql,direct_collaborator
-prombot,prometheus-community/vscode-promql,direct_collaborator
-squat,prometheus-community/vscode-promql,direct_collaborator
-aleroyer,prometheus-community/rsyslog_exporter,direct_collaborator
-prombot,prometheus-community/monaco-promql,direct_collaborator
-bluecmd,prometheus-community/fortigate_exporter,direct_collaborator
-secustor,prometheus-community/fortigate_exporter,direct_collaborator
-prombot,prometheus-community/fortigate_exporter,direct_collaborator
-prombot,prometheus-community/sublimelsp-promql,direct_collaborator
-prombot,prometheus-community/helm-charts,direct_collaborator
-prombot,prometheus-community/ecs_exporter,direct_collaborator
-prombot,prometheus-community/ansible,direct_collaborator
-prombot,prometheus-community/go-runit,direct_collaborator
-AndrejKiri,prometheus-community/ux-research,direct_collaborator
-prombot,prometheus-community/ux-research,direct_collaborator
-amy-super,prometheus-community/ux-research,direct_collaborator
-MichaHoffmann,prometheus-community/parquet-wg,direct_collaborator
-prombot,prometheus-community/parquet-wg,direct_collaborator
-alanprot,prometheus-community/parquet-common,direct_collaborator
-francoposa,prometheus-community/parquet-common,direct_collaborator
-MichaHoffmann,prometheus-community/parquet-common,direct_collaborator
-prombot,prometheus-community/parquet-common,direct_collaborator
-yeya24,prometheus-community/parquet-common,direct_collaborator
-npazosmendez,prometheus-community/parquet-common,direct_collaborator
-celian-garcia,prometheus-community/highlightjs-promql,direct_collaborator
-MichaHoffmann,prometheus-community/parmetheus,direct_collaborator
-
+# Generated at: 2026-05-26T14:27:04Z
+login,source,access_type,name,email
+aknuds1,prometheus,org_member,,
+alexgreenbank,prometheus,org_member,,
+ArthurSens,prometheus,org_member,,
+bastischubert,prometheus,org_member,,
+bboreham,prometheus,org_member,,
+bitfehler,prometheus,org_member,,
+brancz,prometheus,org_member,,
+breed808,prometheus,org_member,,
+bwplotka,prometheus,org_member,,
+caniszczyk,prometheus,org_member,,
+carlpett,prometheus,org_member,,
+carrieedwards,prometheus,org_member,,
+codesome,prometheus,org_member,,
+cristiangreco,prometheus,org_member,,
+csmarchbanks,prometheus,org_member,,
+cstyan,prometheus,org_member,,
+dashpole,prometheus,org_member,,
+dgl,prometheus,org_member,,
+dhoard,prometheus,org_member,,
+discordianfish,prometheus,org_member,,
+dmagliola,prometheus,org_member,,
+dswarbrick,prometheus,org_member,,
+electron0zero,prometheus,org_member,,
+fionaliao,prometheus,org_member,,
+fstab,prometheus,org_member,,
+gardar,prometheus,org_member,,
+gotjosh,prometheus,org_member,,
+gouthamve,prometheus,org_member,,
+grobie,prometheus,org_member,,
+grobinson-grafana,prometheus,org_member,,
+jan--f,prometheus,org_member,,
+jesusvazquez,prometheus,org_member,,
+jkroepke,prometheus,org_member,,
+juliusv,prometheus,org_member,,
+kakkoyun,prometheus,org_member,,
+krajorama,prometheus,org_member,,
+machine424,prometheus,org_member,,
+matthiasr,prometheus,org_member,,
+mem,prometheus,org_member,,
+metalmatze,prometheus,org_member,,
+mxinden,prometheus,org_member,,
+Nexucis,prometheus,org_member,,
+npazosmendez,prometheus,org_member,,
+paulfantom,prometheus,org_member,,
+pedro-stanaka,prometheus,org_member,,
+pgier,prometheus,org_member,,
+prombot,prometheus,org_member,,
+rajagopalanand,prometheus,org_member,,
+RichiH,prometheus,org_member,,
+roidelapluie,prometheus,org_member,,
+saswatamcode,prometheus,org_member,,
+siavashs,prometheus,org_member,,
+simonpasquier,prometheus,org_member,,
+Sinjo,prometheus,org_member,,
+SoloJacobs,prometheus,org_member,,
+Spaceman1701,prometheus,org_member,,
+SuperQ,prometheus,org_member,,
+sysadmind,prometheus,org_member,,
+thelinuxfoundation,prometheus,org_member,,
+TheMeier,prometheus,org_member,,
+thomaspeitz,prometheus,org_member,,
+tombrk,prometheus,org_member,,
+tomwilkie,prometheus,org_member,,
+ultrotter,prometheus,org_member,,
+vesari,prometheus,org_member,,
+w0rm,prometheus,org_member,,
+waltherlee,prometheus,org_member,,
+yaacov,prometheus,org_member,,
+ywwg,prometheus,org_member,,
+zeitlinger,prometheus,org_member,,
+acondrat,prometheus-community,org_member,,
+aleroyer,prometheus-community,org_member,,
+andrewgkew,prometheus-community,org_member,,
+andriikushch,prometheus-community,org_member,,
+arslanbekov,prometheus-community,org_member,,
+arthlr,prometheus-community,org_member,,
+ArthurSens,prometheus-community,org_member,,
+asherf,prometheus-community,org_member,,
+bastischubert,prometheus-community,org_member,,
+bitfehler,prometheus-community,org_member,,
+bluecmd,prometheus-community,org_member,,
+brancz,prometheus-community,org_member,,
+breed808,prometheus-community,org_member,,
+bwplotka,prometheus-community,org_member,,
+caarlos0,prometheus-community,org_member,,
+caniszczyk,prometheus-community,org_member,,
+carlpett,prometheus-community,org_member,,
+celian-garcia,prometheus-community,org_member,,
+codesome,prometheus-community,org_member,,
+cristiangreco,prometheus-community,org_member,,
+csmarchbanks,prometheus-community,org_member,,
+cstaud,prometheus-community,org_member,,
+cstyan,prometheus-community,org_member,,
+dacamposol,prometheus-community,org_member,,
+derekmarcotte,prometheus-community,org_member,,
+desaintmartin,prometheus-community,org_member,,
+discordianfish,prometheus-community,org_member,,
+dongjiang1989,prometheus-community,org_member,,
+dotdc,prometheus-community,org_member,,
+DrFaust92,prometheus-community,org_member,,
+dswarbrick,prometheus-community,org_member,,
+erdii,prometheus-community,org_member,,
+fabxc,prometheus-community,org_member,,
+free,prometheus-community,org_member,,
+frodenas,prometheus-community,org_member,,
+gardar,prometheus-community,org_member,,
+geekodour,prometheus-community,org_member,,
+gianrubio,prometheus-community,org_member,,
+gkarthiks,prometheus-community,org_member,,
+GMartinez-Sisti,prometheus-community,org_member,,
+golgoth31,prometheus-community,org_member,,
+gouthamve,prometheus-community,org_member,,
+grobie,prometheus-community,org_member,,
+hectorj2f,prometheus-community,org_member,,
+iamabhishek-dubey,prometheus-community,org_member,,
+igaskin,prometheus-community,org_member,,
+JessicaGreben,prometheus-community,org_member,,
+jesusvazquez,prometheus-community,org_member,,
+jkroepke,prometheus-community,org_member,,
+Juanchimienti,prometheus-community,org_member,,
+juliusv,prometheus-community,org_member,,
+kawamuray,prometheus-community,org_member,,
+kfox1111,prometheus-community,org_member,,
+kgeckhart,prometheus-community,org_member,,
+lexfrei,prometheus-community,org_member,,
+lilic,prometheus-community,org_member,,
+lucperkins,prometheus-community,org_member,,
+marthjod,prometheus-community,org_member,,
+martinlindhe,prometheus-community,org_member,,
+matthiasr,prometheus-community,org_member,,
+MattiasGees,prometheus-community,org_member,,
+maximee-leroyy,prometheus-community,org_member,,
+maxwo,prometheus-community,org_member,,
+metalmatze,prometheus-community,org_member,,
+monotek,prometheus-community,org_member,,
+mrueg,prometheus-community,org_member,,
+mxinden,prometheus-community,org_member,,
+naseemkullah,prometheus-community,org_member,,
+nevill,prometheus-community,org_member,,
+Nexucis,prometheus-community,org_member,,
+NiceGuyIT,prometheus-community,org_member,,
+nlamirault,prometheus-community,org_member,,
+okgolove,prometheus-community,org_member,,
+openenergyprojects,prometheus-community,org_member,,
+paulfantom,prometheus-community,org_member,,
+povilasv,prometheus-community,org_member,,
+prombot,prometheus-community,org_member,,
+QuentinBisson,prometheus-community,org_member,,
+rakyll,prometheus-community,org_member,,
+rayram23,prometheus-community,org_member,,
+RichiH,prometheus-community,org_member,,
+roidelapluie,prometheus-community,org_member,,
+rpahli,prometheus-community,org_member,,
+rsicart,prometheus-community,org_member,,
+rsotnychenko,prometheus-community,org_member,,
+rustycl0ck,prometheus-community,org_member,,
+s-urbaniak,prometheus-community,org_member,,
+scDisorder,prometheus-community,org_member,,
+schmiddim,prometheus-community,org_member,,
+scottrigby,prometheus-community,org_member,,
+Sheridan,prometheus-community,org_member,,
+simonfrey,prometheus-community,org_member,,
+simonpasquier,prometheus-community,org_member,,
+slrtbtfs,prometheus-community,org_member,,
+squat,prometheus-community,org_member,,
+stanhu,prometheus-community,org_member,,
+steven-sheehy,prometheus-community,org_member,,
+stewartshea,prometheus-community,org_member,,
+stuartnelson3,prometheus-community,org_member,,
+SuperQ,prometheus-community,org_member,,
+svenmueller,prometheus-community,org_member,,
+sysadmind,prometheus-community,org_member,,
+tariq1890,prometheus-community,org_member,,
+thomaspeitz,prometheus-community,org_member,,
+timm088,prometheus-community,org_member,,
+tomwilkie,prometheus-community,org_member,,
+torstenwalter,prometheus-community,org_member,,
+tristanburgess,prometheus-community,org_member,,
+vesari,prometheus-community,org_member,,
+vsliouniaev,prometheus-community,org_member,,
+walker-tom,prometheus-community,org_member,,
+wilfriedroset,prometheus-community,org_member,,
+wrouesnel,prometheus-community,org_member,,
+xiu,prometheus-community,org_member,,
+Xtigyro,prometheus-community,org_member,,
+zanhsieh,prometheus-community,org_member,,
+zeritti,prometheus-community,org_member,,
+zwopir,prometheus-community,org_member,,
+remyleone,prometheus/prometheus,direct_collaborator,,
+apricote,prometheus/prometheus,direct_collaborator,,
+jooola,prometheus/prometheus,direct_collaborator,,
+matt-gp,prometheus/prometheus,direct_collaborator,,
+mrvarmazyar,prometheus/prometheus,direct_collaborator,,
+rexagod,prometheus/prometheus,direct_collaborator,,
+ArthurSens,prometheus/client_golang,direct_collaborator,,
+martincostello,prometheus/client_java,direct_collaborator,,
+zeitlinger,prometheus/client_java,direct_collaborator,,
+jaydeluca,prometheus/client_java,direct_collaborator,,
+dhoard,prometheus/client_java,direct_collaborator,,
+jack-berg,prometheus/client_java,direct_collaborator,,
+Sinjo,prometheus/client_ruby,direct_collaborator,,
+dmagliola,prometheus/client_ruby,direct_collaborator,,
+SuperQ,prometheus/statsd_exporter,direct_collaborator,,
+grobinson-grafana,prometheus/alertmanager,direct_collaborator,,
+fstab,prometheus/jmx_exporter,direct_collaborator,,
+zeitlinger,prometheus/jmx_exporter,direct_collaborator,,
+jaydeluca,prometheus/jmx_exporter,direct_collaborator,,
+dhoard,prometheus/jmx_exporter,direct_collaborator,,
+pgier,prometheus/procfs,direct_collaborator,,
+bastischubert,prometheus/snmp_exporter,direct_collaborator,,
+mem,prometheus/blackbox_exporter,direct_collaborator,,
+yaacov,prometheus/prometheus_api_client_ruby,direct_collaborator,,
+SuperQ,prometheus/talks,direct_collaborator,,
+gardar,prometheus/demo-site,direct_collaborator,,
+paulfantom,prometheus/demo-site,direct_collaborator,,
+simonpasquier,prometheus/circleci,direct_collaborator,,
+mxinden,prometheus/client_rust,direct_collaborator,,
+krisztianfekete,prometheus/client_rust,direct_collaborator,,
+tomwilkie,prometheus/compliance,direct_collaborator,,
+bwplotka,prometheus/proposals,direct_collaborator,,
+ldufr,prometheus/test-sd-ownership,direct_collaborator,,
+metalmatze,prometheus-community/elasticsearch_exporter,direct_collaborator,,
+marthjod,prometheus-community/elasticsearch_exporter,direct_collaborator,,
+zwopir,prometheus-community/elasticsearch_exporter,direct_collaborator,,
+prombot,prometheus-community/elasticsearch_exporter,direct_collaborator,,
+simonfrey,prometheus-community/elasticsearch_exporter,direct_collaborator,,
+prombot,prometheus-community/postgres_exporter,direct_collaborator,,
+prombot,prometheus-community/bind_exporter,direct_collaborator,,
+prombot,prometheus-community/json_exporter,direct_collaborator,,
+martinlindhe,prometheus-community/windows_exporter,direct_collaborator,,
+carlpett,prometheus-community/windows_exporter,direct_collaborator,,
+prombot,prometheus-community/windows_exporter,direct_collaborator,,
+prombot,prometheus-community/stackdriver_exporter,direct_collaborator,,
+prombot,prometheus-community/PushProx,direct_collaborator,,
+prombot,prometheus-community/yet-another-cloudwatch-exporter,direct_collaborator,,
+prombot,prometheus-community/pgbouncer_exporter,direct_collaborator,,
+prombot,prometheus-community/ipmi_exporter,direct_collaborator,,
+prombot,prometheus-community/avalanche,direct_collaborator,,
+saswatamcode,prometheus-community/avalanche,direct_collaborator,,
+brancz,prometheus-community/prom-label-proxy,direct_collaborator,,
+prombot,prometheus-community/prom-label-proxy,direct_collaborator,,
+prom-label-proxy-bot,prometheus-community/prom-label-proxy,direct_collaborator,,
+lucperkins,prometheus-community/prometheus-playground,direct_collaborator,,
+prombot,prometheus-community/snmp,direct_collaborator,,
+povilasv,prometheus-community/community,direct_collaborator,,
+discordianfish,prometheus-community/node-exporter-textfile-collector-scripts,direct_collaborator,,
+prombot,prometheus-community/node-exporter-textfile-collector-scripts,direct_collaborator,,
+prombot,prometheus-community/smartctl_exporter,direct_collaborator,,
+nevill,prometheus-community/prometheus,direct_collaborator,,
+geekodour,prometheus-community/prometheus,direct_collaborator,,
+slrtbtfs,prometheus-community/promql-langserver,direct_collaborator,,
+prombot,prometheus-community/promql-langserver,direct_collaborator,,
+squat,prometheus-community/promql-langserver,direct_collaborator,,
+ant31,prometheus-community/vscode-promql,direct_collaborator,,
+simonpasquier,prometheus-community/vscode-promql,direct_collaborator,,
+slrtbtfs,prometheus-community/vscode-promql,direct_collaborator,,
+prombot,prometheus-community/vscode-promql,direct_collaborator,,
+squat,prometheus-community/vscode-promql,direct_collaborator,,
+aleroyer,prometheus-community/rsyslog_exporter,direct_collaborator,,
+prombot,prometheus-community/monaco-promql,direct_collaborator,,
+bluecmd,prometheus-community/fortigate_exporter,direct_collaborator,,
+secustor,prometheus-community/fortigate_exporter,direct_collaborator,,
+prombot,prometheus-community/fortigate_exporter,direct_collaborator,,
+prombot,prometheus-community/sublimelsp-promql,direct_collaborator,,
+prombot,prometheus-community/helm-charts,direct_collaborator,,
+prombot,prometheus-community/ecs_exporter,direct_collaborator,,
+prombot,prometheus-community/ansible,direct_collaborator,,
+prombot,prometheus-community/go-runit,direct_collaborator,,
+AndrejKiri,prometheus-community/ux-research,direct_collaborator,,
+prombot,prometheus-community/ux-research,direct_collaborator,,
+amy-super,prometheus-community/ux-research,direct_collaborator,,
+MichaHoffmann,prometheus-community/parquet-wg,direct_collaborator,,
+prombot,prometheus-community/parquet-wg,direct_collaborator,,
+alanprot,prometheus-community/parquet-common,direct_collaborator,,
+francoposa,prometheus-community/parquet-common,direct_collaborator,,
+MichaHoffmann,prometheus-community/parquet-common,direct_collaborator,,
+prombot,prometheus-community/parquet-common,direct_collaborator,,
+yeya24,prometheus-community/parquet-common,direct_collaborator,,
+npazosmendez,prometheus-community/parquet-common,direct_collaborator,,
+celian-garcia,prometheus-community/highlightjs-promql,direct_collaborator,,
+MichaHoffmann,prometheus-community/parmetheus,direct_collaborator,,
+bboreham,prometheus/prometheus,maintainer,Bryan Boreham,bjboreham@gmail.com
+machine424,prometheus/prometheus,maintainer,Ayoub Mrini,ayoubmrini424@gmail.com
+roidelapluie,prometheus/prometheus,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+krajorama,prometheus/prometheus,maintainer,György Krajcsovits,gyorgy.krajcsovits@grafana.com
+bwplotka,prometheus/prometheus,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+aknuds1,prometheus/prometheus,maintainer,Arve Knudsen,arve.knudsen@gmail.com
+dgl,prometheus/prometheus,maintainer,David Leadbeater,dgl@dgl.cx
+jooola,prometheus/prometheus,maintainer,,
+brancz,prometheus/prometheus,maintainer,Frederic Branczyk,fbranczyk@gmail.com
+rexagod,prometheus/prometheus,maintainer,Pranshu Srivastava,rexagod@gmail.com
+jkroepke,prometheus/prometheus,maintainer,Jan-Otto Kröpke,mail@jkroepke.de
+mrvarmazyar,prometheus/prometheus,maintainer,Mohammad Varmazyar,mrvarmazyar@gmail.com
+remyleone,prometheus/prometheus,maintainer,Rémy Léone,rleone@scaleway.com
+metalmatze,prometheus/prometheus,maintainer,Matthias Loibl,mail@matthiasloibl.com
+cstyan,prometheus/prometheus,maintainer,Callum Styan,callumstyan@gmail.com
+tomwilkie,prometheus/prometheus,maintainer,Tom Wilkie,tom.wilkie@gmail.com
+alexgreenbank,prometheus/prometheus,maintainer,Alex Greenbank,alexgreenbank@yahoo.com
+ArthurSens,prometheus/prometheus,maintainer,Arthur Silva Sens,arthursens2005@gmail.com
+jesusvazquez,prometheus/prometheus,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+codesome,prometheus/prometheus,maintainer,Ganesh Vernekar,ganesh@grafana.com
+jesusvazquez,prometheus/prometheus,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+kgeckhart,prometheus/prometheus,maintainer,Kyle Eckhart,kyle.eckhart@grafana.com
+juliusv,prometheus/prometheus,maintainer,Julius Volz,julius.volz@gmail.com
+Nexucis,prometheus/prometheus,maintainer,Augustin Husson,husson.augustin@gmail.com
+simonpasquier,prometheus/prometheus,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+SuperQ,prometheus/prometheus,maintainer,Ben Kochie,superq@gmail.com
+alexgreenbank,prometheus/prometheus,maintainer,Alex Greenbank,alexgreenbank@yahoo.com
+carrieedwards,prometheus/prometheus,maintainer,Carrie Edwards,carrie.edwards@grafana.com
+fionaliao,prometheus/prometheus,maintainer,Fiona Liao,fiona.liao@grafana.com
+jan--f,prometheus/prometheus,maintainer,Jan Fajerski,github@fajerski.name
+jesusvazquez,prometheus/prometheus,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+npazosmendez,prometheus/prometheus,maintainer,Nico Pazos,nicolas.pazos-mendez@grafana.com
+ywwg,prometheus/prometheus,maintainer,Owen Williams,owen.williams@grafana.com
+vesari,prometheus/client_golang,maintainer,Arianna Vespri,arianna.vespri@proton.me
+bwplotka,prometheus/client_golang,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+kakkoyun,prometheus/client_golang,maintainer,Kemal Akkoyun,kakkoyun@gmail.com
+fstab,prometheus/client_java,maintainer,Fabian Stäber,fabian@fstab.de
+dhoard,prometheus/client_java,maintainer,Doug Hoard,doug.hoard@gmail.com
+zeitlinger,prometheus/client_java,maintainer,Gregor Zeitlinger,gregor.zeitlinger@grafana.com
+jaydeluca,prometheus/client_java,maintainer,Jay DeLuca,jaydeluca4@gmail.com
+SuperQ,prometheus/node_exporter,maintainer,Ben Kochie,superq@gmail.com
+discordianfish,prometheus/node_exporter,maintainer,Johannes 'fish' Ziemke,github@freigeist.org
+SuperQ,prometheus/client_ruby,maintainer,Ben Kochie,superq@gmail.com
+dmagliola,prometheus/client_ruby,maintainer,Daniel Magliola,dmagliola@crystalgears.com
+bwplotka,prometheus/client_model,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+matthiasr,prometheus/statsd_exporter,maintainer,Matthias Rampke,matthias@prometheus.io
+pedro-stanaka,prometheus/statsd_exporter,maintainer,Pedro Tanaka,me@pedrotanaka.com.br
+simonpasquier,prometheus/alertmanager,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+w0rm,prometheus/alertmanager,maintainer,Andrey Kuzmin,unsoundscapes@gmail.com
+gotjosh,prometheus/alertmanager,maintainer,Josue Abreu,josue.abreu@gmail.com
+grobinson-grafana,prometheus/alertmanager,maintainer,George Robinson,george.robinson@grafana.com
+SoloJacobs,prometheus/alertmanager,maintainer,Solomon Jacobs,solomonjacobs@protonmail.com
+Spaceman1701,prometheus/alertmanager,maintainer,Ethan Hunter,fc.spaceman@gmail.com
+ultrotter,prometheus/alertmanager,maintainer,Guido Trotter,ultrotter@gmail.com
+siavashs,prometheus/alertmanager,maintainer,Siavash Safi,siavash@cloudflare.com
+machine424,prometheus/pushgateway,maintainer,Ayoub Mrini,ayoubmrini424@gmail.com
+jan--f,prometheus/pushgateway,maintainer,Jan Fajerski,github@fajerski.name
+dhoard,prometheus/jmx_exporter,maintainer,Doug Hoard,doug.hoard@gmail.com
+fstab,prometheus/jmx_exporter,maintainer,Fabian Stäber,fabian@fstab.de
+bwplotka,prometheus/prom2json,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+juliusv,prometheus/docs,maintainer,Julius Volz,julius.volz@gmail.com
+RichiH,prometheus/docs,maintainer,Richard Hartmann,richih@richih.org
+discordianfish,prometheus/procfs,maintainer,Johannes 'fish' Ziemke,github@freigeist.org
+pgier,prometheus/procfs,maintainer,Paul Gier,paulgier@gmail.com
+SuperQ,prometheus/procfs,maintainer,Ben Kochie,superq@gmail.com
+matthiasr,prometheus/cloudwatch_exporter,maintainer,Matthias Rampke,matthias@prometheus.io
+juliusv,prometheus/collectd_exporter,maintainer,Julius Volz,julius.volz@gmail.com
+csmarchbanks,prometheus/client_python,maintainer,Chris Marchbanks,csmarchbanks@gmail.com
+bastischubert,prometheus/snmp_exporter,maintainer,Basti Schubert,basti@schubert.digital
+SuperQ,prometheus/snmp_exporter,maintainer,Ben Kochie,superq@gmail.com
+RichiH,prometheus/snmp_exporter,maintainer,Richard Hartmann,richih@richih.org
+SuperQ,prometheus/mysqld_exporter,maintainer,Ben Kochie,superq@gmail.com
+simonpasquier,prometheus/consul_exporter,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+pedro-stanaka,prometheus/graphite_exporter,maintainer,Pedro Tanaka,
+roidelapluie,prometheus/common,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+gotjosh,prometheus/common,maintainer,Josue,josue.abreu@gmail.com
+roidelapluie,prometheus/blackbox_exporter,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+mem,prometheus/blackbox_exporter,maintainer,Marcelo Magallon,marcelo.magallon@grafana.com
+electron0zero,prometheus/blackbox_exporter,maintainer,Suraj Nath,suraj.sidh@grafana.com
+kakkoyun,prometheus/promu,maintainer,Kemal Akkoyun,kakkoyun@gmail.com
+grobie,prometheus/memcached_exporter,maintainer,Tobias Schmidt,tobidt@gmail.com
+kakkoyun,prometheus/test-infra,maintainer,Kemal Akkoyun,kakkoyun@gmail.com
+bwplotka,prometheus/test-infra,maintainer,Bartek Plotka,bwplotka@gmail.com
+RichiH,prometheus/promcon,maintainer,Richard Hartmann,richih@richih.org
+yaacov,prometheus/prometheus_api_client_ruby,maintainer,Yaacov Zamir,kobi.zamir@gmail.com
+SuperQ,prometheus/talks,maintainer,Ben Kochie,superq@gmail.com
+RichiH,prometheus/talks,maintainer,Richard Hartmann,richih@richih.org
+SuperQ,prometheus/demo-site,maintainer,Ben Kochie,superq@gmail.com
+gardar,prometheus/demo-site,maintainer,Garðar Arnarsson,github@gardar.net
+paulfantom,prometheus/demo-site,maintainer,Paweł Krupa,paulfantom@gmail.com
+simonpasquier,prometheus/circleci,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+SuperQ,prometheus/exporter-toolkit,maintainer,Ben Kochie,superq@gmail.com
+roidelapluie,prometheus/exporter-toolkit,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+krisztianfekete,prometheus/client_rust,maintainer,Krisztian Fekete,prometheus@krisztianfekete.org
+SuperQ,prometheus/snmp_exporter_mibs,maintainer,Ben Kochie,superq@gmail.com
+RichiH,prometheus/snmp_exporter_mibs,maintainer,Richard Hartmann,richih@richih.org
+tomwilkie,prometheus/compliance,maintainer,Tom Wilkie,tom.wilkie@gmail.com
+RichiH,prometheus/compliance,maintainer,"Richard ""RichiH"" Hartmann",richih@richih.org
+juliusv,prometheus/compliance,maintainer,Julius Volz,julius.volz@gmail.com
+juliusv,prometheus/promlens,maintainer,Julius Volz,julius.volz@gmail.com
+roidelapluie,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+dgl,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,David Leadbeater,dgl@dgl.cx
+brancz,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Frederic Branczyk,fbranczyk@gmail.com
+csmarchbanks,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Chris Marchbanks,csmarchbanks@gmail.com
+cstyan,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Callum Styan,callumstyan@gmail.com
+bwplotka,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+tomwilkie,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Tom Wilkie,tom.wilkie@gmail.com
+codesome,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Ganesh Vernekar,ganesh@grafana.com
+bwplotka,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+juliusv,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Julius Volz,julius.volz@gmail.com
+Nexucis,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Augustin Husson,husson.augustin@gmail.com
+simonpasquier,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+SuperQ,prometheus/prometheus-ghsa-p54f-935g-x7j2,maintainer,Ben Kochie,superq@gmail.com
+roidelapluie,prometheus/sigv4,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+gotjosh,prometheus/sigv4,maintainer,Josue,josue.abreu@gmail.com
+ArthurSens,prometheus/otlptranslator,maintainer,Arthur Silva Sens,arthursens2005@gmail.com
+aknuds1,prometheus/otlptranslator,maintainer,Arve Knudsen,arve.knudsen@gmail.com
+jesusvazquez,prometheus/otlptranslator,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+ywwg,prometheus/otlptranslator,maintainer,Owen Williams,owen.williams@grafana.com
+roidelapluie,prometheus/common-ghsa-qmwc-fc99-jm3h,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+gotjosh,prometheus/common-ghsa-qmwc-fc99-jm3h,maintainer,Josue,josue.abreu@gmail.com
+SuperQ,prometheus-community/elasticsearch_exporter,maintainer,Ben Kochie,superq@gmail.com
+sysadmind,prometheus-community/elasticsearch_exporter,maintainer,Joe Adams,github@joeadams.io
+SuperQ,prometheus-community/postgres_exporter,maintainer,Ben Kochie,superq@gmail.com
+wrouesnel,prometheus-community/postgres_exporter,maintainer,William Rouesnel,wrouesnel@wrouesnel.com
+sysadmind,prometheus-community/postgres_exporter,maintainer,Joe Adams,github@joeadams.io
+SuperQ,prometheus-community/bind_exporter,maintainer,Ben Kochie,superq@gmail.com
+SuperQ,prometheus-community/json_exporter,maintainer,Ben Kochie,superq@gmail.com
+rustycl0ck,prometheus-community/json_exporter,maintainer,Ravi,rustyclock@protonmail.com
+breed808,prometheus-community/windows_exporter,maintainer,Ben Reedy,breed808@breed808.com
+jkroepke,prometheus-community/windows_exporter,maintainer,Jan-Otto Kröpke,github@jkroepke.de
+SuperQ,prometheus-community/stackdriver_exporter,maintainer,Ben Kochie,superq@gmail.com
+kgeckhart,prometheus-community/stackdriver_exporter,maintainer,Kyle Eckhart,kgeckhart@gmail.com
+thomaspeitz,prometheus-community/yet-another-cloudwatch-exporter,maintainer,Thomas Peitz,info@thomas-peitz.de
+cristiangreco,prometheus-community/yet-another-cloudwatch-exporter,maintainer,Cristian Greco,cristian.greco@grafana.com
+andriikushch,prometheus-community/yet-another-cloudwatch-exporter,maintainer,Andrii Kushch,andrii.kushch@grafana.com
+tristanburgess,prometheus-community/yet-another-cloudwatch-exporter,maintainer,Tristan Burgess,tristan.burgess@grafana.com
+SuperQ,prometheus-community/pgbouncer_exporter,maintainer,Ben Kochie,superq@gmail.com
+stanhu,prometheus-community/pgbouncer_exporter,maintainer,Stan Hu,stanhu@gmail.com
+bitfehler,prometheus-community/ipmi_exporter,maintainer,Conrad Hoffmann,ch@bitfehler.net
+SuperQ,prometheus-community/ipmi_exporter,maintainer,Ben Kochie,superq@gmail.com
+bwplotka,prometheus-community/avalanche,maintainer,Bartek Płotka,bwplotka@gmail.com
+saswatamcode,prometheus-community/avalanche,maintainer,Saswata Mukherjee,saswata.mukhe@gmail.com
+squat,prometheus-community/prom-label-proxy,maintainer,Lucas Servén Marín,lserven@gmail.com
+simonpasquier,prometheus-community/prom-label-proxy,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+bastischubert,prometheus-community/snmp,maintainer,Basti Schubert,basti@schubert.digital
+SuperQ,prometheus-community/snmp,maintainer,Ben Kochie,superq@gmail.com
+RichiH,prometheus-community/snmp,maintainer,Richard Hartmann,richih@richih.org
+SuperQ,prometheus-community/node-exporter-textfile-collector-scripts,maintainer,Ben Kochie,superq@gmail.com
+dswarbrick,prometheus-community/node-exporter-textfile-collector-scripts,maintainer,Daniel Swarbrick,daniel.swarbrick@gmail.com
+SuperQ,prometheus-community/smartctl_exporter,maintainer,Ben Kochie,superq@gmail.com
+bitfehler,prometheus-community/smartctl_exporter,maintainer,Conrad Hoffmann,ch@bitfehler.net
+NiceGuyIT,prometheus-community/smartctl_exporter,maintainer,David Randall,David@NiceGuyIT.biz
+bboreham,prometheus-community/prometheus,maintainer,Bryan Boreham,bjboreham@gmail.com
+machine424,prometheus-community/prometheus,maintainer,Ayoub Mrini,ayoubmrini424@gmail.com
+roidelapluie,prometheus-community/prometheus,maintainer,Julien Pivotto,roidelapluie@prometheus.io
+krajorama,prometheus-community/prometheus,maintainer,György Krajcsovits,gyorgy.krajcsovits@grafana.com
+bwplotka,prometheus-community/prometheus,maintainer,Bartłomiej Płotka,bwplotka@gmail.com
+aknuds1,prometheus-community/prometheus,maintainer,Arve Knudsen,arve.knudsen@gmail.com
+dgl,prometheus-community/prometheus,maintainer,David Leadbeater,dgl@dgl.cx
+jooola,prometheus-community/prometheus,maintainer,,
+brancz,prometheus-community/prometheus,maintainer,Frederic Branczyk,fbranczyk@gmail.com
+rexagod,prometheus-community/prometheus,maintainer,Pranshu Srivastava,rexagod@gmail.com
+jkroepke,prometheus-community/prometheus,maintainer,Jan-Otto Kröpke,mail@jkroepke.de
+mrvarmazyar,prometheus-community/prometheus,maintainer,Mohammad Varmazyar,mrvarmazyar@gmail.com
+remyleone,prometheus-community/prometheus,maintainer,Rémy Léone,rleone@scaleway.com
+metalmatze,prometheus-community/prometheus,maintainer,Matthias Loibl,mail@matthiasloibl.com
+cstyan,prometheus-community/prometheus,maintainer,Callum Styan,callumstyan@gmail.com
+tomwilkie,prometheus-community/prometheus,maintainer,Tom Wilkie,tom.wilkie@gmail.com
+alexgreenbank,prometheus-community/prometheus,maintainer,Alex Greenbank,alexgreenbank@yahoo.com
+ArthurSens,prometheus-community/prometheus,maintainer,Arthur Silva Sens,arthursens2005@gmail.com
+jesusvazquez,prometheus-community/prometheus,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+codesome,prometheus-community/prometheus,maintainer,Ganesh Vernekar,ganesh@grafana.com
+jesusvazquez,prometheus-community/prometheus,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+juliusv,prometheus-community/prometheus,maintainer,Julius Volz,julius.volz@gmail.com
+Nexucis,prometheus-community/prometheus,maintainer,Augustin Husson,husson.augustin@gmail.com
+simonpasquier,prometheus-community/prometheus,maintainer,Simon Pasquier,pasquier.simon@gmail.com
+SuperQ,prometheus-community/prometheus,maintainer,Ben Kochie,superq@gmail.com
+alexgreenbank,prometheus-community/prometheus,maintainer,Alex Greenbank,alexgreenbank@yahoo.com
+carrieedwards,prometheus-community/prometheus,maintainer,Carrie Edwards,carrie.edwards@grafana.com
+fionaliao,prometheus-community/prometheus,maintainer,Fiona Liao,fiona.liao@grafana.com
+jan--f,prometheus-community/prometheus,maintainer,Jan Fajerski,github@fajerski.name
+jesusvazquez,prometheus-community/prometheus,maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+npazosmendez,prometheus-community/prometheus,maintainer,Nico Pazos,nicolas.pazos-mendez@grafana.com
+ywwg,prometheus-community/prometheus,maintainer,Owen Williams,owen.williams@grafana.com
+aleroyer,prometheus-community/rsyslog_exporter,maintainer,Antoine Leroyer,
+celian-garcia,prometheus-community/monaco-promql,maintainer,Célian Garcia,celian.garcia1@gmail.com
+SuperQ,prometheus-community/fortigate_exporter,maintainer,Ben Kochie,superq@gmail.com
+bastischubert,prometheus-community/fortigate_exporter,maintainer,Basti Schubert,basti@schubert.digital
+monotek,prometheus-community/helm-charts,maintainer,André Bauer,monotek23@gmail.com
+jkroepke,prometheus-community/helm-charts,maintainer,Jan-Otto Kröpke,github@jkroepke.de
+scottrigby,prometheus-community/helm-charts,maintainer,Scott Rigby,scott@r6by.com
+torstenwalter,prometheus-community/helm-charts,maintainer,Torsten Walter,mail@torstenwalter.de
+GMartinez-Sisti,prometheus-community/helm-charts,maintainer,Gabriel Martinez,kube-prometheus-stack@sisti.pt
+maxwo,prometheus-community/helm-charts,maintainer,maxwo,maxime.wojtczak.pub@icloud.com
+monotek,prometheus-community/helm-charts,maintainer,monotek,monotek23@gmail.com
+naseemkullah,prometheus-community/helm-charts,maintainer,naseemkullah,naseem@transit.app
+jkroepke,prometheus-community/helm-charts,maintainer,Jan-Otto Kröpke,github@jkroepke.de
+zanhsieh,prometheus-community/helm-charts,maintainer,zanhsieh,zanhsieh@gmail.com
+GMartinez-Sisti,prometheus-community/helm-charts,maintainer,GMartinez-Sisti,kube-prometheus-stack@sisti.pt
+QuentinBisson,prometheus-community/helm-charts,maintainer,QuentinBisson,quentin.bisson@gmail.com
+Xtigyro,prometheus-community/helm-charts,maintainer,Xtigyro,miroslav.hadzhiev@gmail.com
+andrewgkew,prometheus-community/helm-charts,maintainer,andrewgkew,andrew@quadcorps.co.uk
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+gkarthiks,prometheus-community/helm-charts,maintainer,gkarthiks,github.gkarthiks@gmail.com
+jkroepke,prometheus-community/helm-charts,maintainer,jkroepke,github@jkroepke.de
+dotdc,prometheus-community/helm-charts,maintainer,dotdc,david@0xdc.me
+mrueg,prometheus-community/helm-charts,maintainer,mrueg,manuel@rueg.eu
+tariq1890,prometheus-community/helm-charts,maintainer,tariq1890,tariq.ibrahim@mulesoft.com
+jkroepke,prometheus-community/helm-charts,maintainer,Jan-Otto Kröpke,github@jkroepke.de
+hectorj2f,prometheus-community/helm-charts,maintainer,hectorj2f,hfernandez@mesosphere.com
+MattiasGees,prometheus-community/helm-charts,maintainer,mattiasgees,mattias.gees@jetstack.io
+steven-sheehy,prometheus-community/helm-charts,maintainer,steven-sheehy,
+desaintmartin,prometheus-community/helm-charts,maintainer,desaintmartin,cedric@desaintmartin.fr
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+monotek,prometheus-community/helm-charts,maintainer,monotek,monotek23@gmail.com
+rsotnychenko,prometheus-community/helm-charts,maintainer,rsotnychenko,me@sota.sh
+asherf,prometheus-community/helm-charts,maintainer,asherf,asher@asherfoa.com
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+torstenwalter,prometheus-community/helm-charts,maintainer,torstenwalter,mail@torstenwalter.de
+monotek,prometheus-community/helm-charts,maintainer,monotek,monotek23@gmail.com
+gkarthiks,prometheus-community/helm-charts,maintainer,gkarthiks,github.gkarthiks@gmail.com
+timm088,prometheus-community/helm-charts,maintainer,timm088,8890118+timm088@users.noreply.github.com
+gkarthiks,prometheus-community/helm-charts,maintainer,gkarthiks,github.gkarthiks@gmail.com
+iamabhishek-dubey,prometheus-community/helm-charts,maintainer,iamabhishek-dubey,abhishekbhardwaj510@gmail.com
+desaintmartin,prometheus-community/helm-charts,maintainer,desaintmartin,cedric@desaintmartin.fr
+svenmueller,prometheus-community/helm-charts,maintainer,svenmueller,sven.mueller@commercetools.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+arslanbekov,prometheus-community/helm-charts,maintainer,arslanbekov,arslanbekov@gmail.com
+lexfrei,prometheus-community/helm-charts,maintainer,lexfrei,f@lex.la
+schmiddim,prometheus-community/helm-charts,maintainer,schmiddim,schmiddim@gmx.at
+xiu,prometheus-community/helm-charts,maintainer,xiu,github@xiu.io
+zanhsieh,prometheus-community/helm-charts,maintainer,zanhsieh,zanhsieh@gmail.com
+gkarthiks,prometheus-community/helm-charts,maintainer,gkarthiks,github.gkarthiks@gmail.com
+golgoth31,prometheus-community/helm-charts,maintainer,golgoth31,golgoth31@notrenet.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+rsicart,prometheus-community/helm-charts,maintainer,rsicart,roger.sicart@gmail.com
+openenergyprojects,prometheus-community/helm-charts,maintainer,openenergyprojects,openenergyprojects@gmail.com
+steven-sheehy,prometheus-community/helm-charts,maintainer,steven-sheehy,ssheehy@firescope.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+Juanchimienti,prometheus-community/helm-charts,maintainer,juanchimienti,juan.chimienti@gmail.com
+monotek,prometheus-community/helm-charts,maintainer,monotek,monotek23@gmail.com
+caarlos0,prometheus-community/helm-charts,maintainer,caarlos0,carlos@carlosbecker.com
+okgolove,prometheus-community/helm-charts,maintainer,okgolove,okgolove@markeloff.net
+nlamirault,prometheus-community/helm-charts,maintainer,nlamirault,nicolas.lamirault@gmail.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+zanhsieh,prometheus-community/helm-charts,maintainer,zanhsieh,zanhsieh@gmail.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+jkroepke,prometheus-community/helm-charts,maintainer,Jan-Otto Kröpke,github@jkroepke.de
+QuentinBisson,prometheus-community/helm-charts,maintainer,QuentinBisson,quentin.bisson@gmail.com
+dacamposol,prometheus-community/helm-charts,maintainer,dacamposol,dacamposol@gmail.com
+desaintmartin,prometheus-community/helm-charts,maintainer,desaintmartin,cedric@desaintmartin.fr
+stewartshea,prometheus-community/helm-charts,maintainer,stewartshea,stewart.shea@gmail.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+monotek,prometheus-community/helm-charts,maintainer,monotek,monotek23@gmail.com
+rpahli,prometheus-community/helm-charts,maintainer,rpahli,pahli88@googlemail.com
+dongjiang1989,prometheus-community/helm-charts,maintainer,dongjiang1989,dongjiang1989@126.com
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+zanhsieh,prometheus-community/helm-charts,maintainer,zanhsieh,zanhsieh@gmail.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+cstaud,prometheus-community/helm-charts,maintainer,cstaud,christian.staude@staffbase.com
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+desaintmartin,prometheus-community/helm-charts,maintainer,desaintmartin,cedric@desaintmartin.fr
+iamabhishek-dubey,prometheus-community/helm-charts,maintainer,iamabhishek-dubey,abhishekbhardwaj510@gmail.com
+Juanchimienti,prometheus-community/helm-charts,maintainer,juanchimienti,juan.chimienti@gmail.com
+monotek,prometheus-community/helm-charts,maintainer,monotek,monotek23@gmail.com
+acondrat,prometheus-community/helm-charts,maintainer,acondrat,arcadie.condrat@gmail.com
+zanhsieh,prometheus-community/helm-charts,maintainer,zanhsieh,zanhsieh@gmail.com
+kfox1111,prometheus-community/helm-charts,maintainer,kfox1111,
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+walker-tom,prometheus-community/helm-charts,maintainer,walker-tom,walker.thomas.p@gmail.com
+xiu,prometheus-community/helm-charts,maintainer,xiu,github@xiu.io
+wilfriedroset,prometheus-community/helm-charts,maintainer,wilfriedroset,
+rpahli,prometheus-community/helm-charts,maintainer,rpahli,pahli88@googlemail.com
+scDisorder,prometheus-community/helm-charts,maintainer,scDisorder,d@rovergulf.net
+acondrat,prometheus-community/helm-charts,maintainer,acondrat,arcadie.condrat@gmail.com
+jkroepke,prometheus-community/helm-charts,maintainer,Jan-Otto Kröpke,github@jkroepke.de
+andriikushch,prometheus-community/helm-charts,maintainer,Andrii Kushch,andrii.kushch@grafana.com
+cristiangreco,prometheus-community/helm-charts,maintainer,Cristian Greco,cristian.greco@grafana.com
+thomaspeitz,prometheus-community/helm-charts,maintainer,Thomas Peitz,info@thomas-peitz.de
+tristanburgess,prometheus-community/helm-charts,maintainer,Tristan Burgess,tristan.burgess@grafana.com
+Xtigyro,prometheus-community/helm-charts,maintainer,Xtigyro,miroslav.hadzhiev@gmail.com
+gianrubio,prometheus-community/helm-charts,maintainer,gianrubio,gianrubio@gmail.com
+naseemkullah,prometheus-community/helm-charts,maintainer,naseemkullah,naseem@transit.app
+zanhsieh,prometheus-community/helm-charts,maintainer,zanhsieh,zanhsieh@gmail.com
+zeritti,prometheus-community/helm-charts,maintainer,zeritti,rootsandtrees@posteo.de
+SuperQ,prometheus-community/pro-bing,maintainer,Ben Kochie,superq@gmail.com
+metalmatze,prometheus-community/pro-bing,maintainer,Matthias Loibl,mail@matthiasloibl.com
+SuperQ,prometheus-community/ansible,maintainer,Ben Kochie,superq@gmail.com
+gardar,prometheus-community/ansible,maintainer,Garðar Arnarsson,github@gardar.net
+paulfantom,prometheus-community/ansible,maintainer,Paweł Krupa,paulfantom@gmail.com
+AndrejKiri,prometheus-community/ux-research,maintainer,Andrej Kiripolsky,andrej.kiripolsky@gmail.com
+amy-super,prometheus-community/ux-research,maintainer,Amy Super,amy.super@grafana.com
+ArthurSens,prometheus-community/ux-research,maintainer,Arthur Sens,arthursens2005@gmail.com
+celian-garcia,prometheus-community/highlightjs-promql,maintainer,Célian Garcia,celian.garcia1@gmail.com

--- a/elections/2026/voters-list/write-access.csv
+++ b/elections/2026/voters-list/write-access.csv
@@ -1,175 +1,174 @@
-# Generated at: 2026-04-30T08:47:28Z
-login,sources,access_types
-acondrat,prometheus-community,org_member
-aknuds1,prometheus,org_member
-alanprot,prometheus-community/parquet-common,direct_collaborator
-aleroyer,prometheus-community;prometheus-community/rsyslog_exporter,org_member;direct_collaborator
-alexgreenbank,prometheus,org_member
-amy-super,prometheus-community/ux-research,direct_collaborator
-AndrejKiri,prometheus-community/ux-research,direct_collaborator
-andrewgkew,prometheus-community,org_member
-andriikushch,prometheus-community,org_member
-ant31,prometheus-community/vscode-promql,direct_collaborator
-apricote,prometheus/prometheus,direct_collaborator
-arslanbekov,prometheus-community,org_member
-arthlr,prometheus-community,org_member
-ArthurSens,prometheus;prometheus-community;prometheus/client_golang,org_member;org_member;direct_collaborator
-asherf,prometheus-community,org_member
-bastischubert,prometheus;prometheus-community;prometheus/snmp_exporter,org_member;org_member;direct_collaborator
-bboreham,prometheus,org_member
-beorn7,prometheus;prometheus-community,org_member;org_member
-bitfehler,prometheus;prometheus-community,org_member;org_member
-bluecmd,prometheus-community;prometheus-community/fortigate_exporter,org_member;direct_collaborator
-brancz,prometheus;prometheus-community;prometheus-community/prom-label-proxy,org_member;org_member;direct_collaborator
-breed808,prometheus;prometheus-community,org_member;org_member
-bwplotka,prometheus;prometheus-community;prometheus/proposals,org_member;org_member;direct_collaborator
-caarlos0,prometheus-community,org_member
-caniszczyk,prometheus;prometheus-community,org_member;org_member
-carlpett,prometheus;prometheus-community;prometheus-community/windows_exporter,org_member;org_member;direct_collaborator
-carrieedwards,prometheus,org_member
-celian-garcia,prometheus-community;prometheus-community/highlightjs-promql,org_member;direct_collaborator
-codesome,prometheus;prometheus-community,org_member;org_member
-cristiangreco,prometheus;prometheus-community,org_member;org_member
-csmarchbanks,prometheus;prometheus-community,org_member;org_member
-cstaud,prometheus-community,org_member
-cstyan,prometheus;prometheus-community,org_member;org_member
-dacamposol,prometheus-community,org_member
-dashpole,prometheus,org_member
-derekmarcotte,prometheus-community;prometheus-community/kitefactory,org_member;direct_collaborator
-desaintmartin,prometheus-community,org_member
-dgl,prometheus,org_member
-dhoard,prometheus;prometheus/client_java;prometheus/jmx_exporter,org_member;direct_collaborator;direct_collaborator
-discordianfish,prometheus;prometheus-community;prometheus-community/node-exporter-textfile-collector-scripts,org_member;org_member;direct_collaborator
-dmagliola,prometheus;prometheus/client_ruby,org_member;direct_collaborator
-dongjiang1989,prometheus-community,org_member
-dotdc,prometheus-community,org_member
-DrFaust92,prometheus-community,org_member
-dswarbrick,prometheus;prometheus-community,org_member;org_member
-electron0zero,prometheus,org_member
-erdii,prometheus-community,org_member
-fabxc,prometheus-community,org_member
-fionaliao,prometheus,org_member
-francoposa,prometheus-community/parquet-common,direct_collaborator
-free,prometheus-community,org_member
-frodenas,prometheus-community,org_member
-fstab,prometheus;prometheus/jmx_exporter,org_member;direct_collaborator
-gardar,prometheus;prometheus-community;prometheus/demo-site,org_member;org_member;direct_collaborator
-geekodour,prometheus-community;prometheus-community/prometheus,org_member;direct_collaborator
-gianrubio,prometheus-community,org_member
-gkarthiks,prometheus-community,org_member
-GMartinez-Sisti,prometheus-community,org_member
-golgoth31,prometheus-community,org_member
-gotjosh,prometheus,org_member
-gouthamve,prometheus;prometheus-community,org_member;org_member
-grobie,prometheus;prometheus-community,org_member;org_member
-grobinson-grafana,prometheus;prometheus/alertmanager,org_member;direct_collaborator
-hectorj2f,prometheus-community,org_member
-iamabhishek-dubey,prometheus-community,org_member
-igaskin,prometheus-community,org_member
-jack-berg,prometheus/client_java,direct_collaborator
-jan--f,prometheus,org_member
-jaydeluca,prometheus/client_java;prometheus/jmx_exporter,direct_collaborator;direct_collaborator
-JessicaGreben,prometheus-community,org_member
-jesusvazquez,prometheus;prometheus-community,org_member;org_member
-jkroepke,prometheus;prometheus-community,org_member;org_member
-jooola,prometheus/prometheus,direct_collaborator
-Juanchimienti,prometheus-community,org_member
-juliusv,prometheus;prometheus-community,org_member;org_member
-kakkoyun,prometheus,org_member
-kawamuray,prometheus-community,org_member
-kfox1111,prometheus-community,org_member
-kgeckhart,prometheus-community,org_member
-krajorama,prometheus,org_member
-ldufr,prometheus/test-sd-ownership,direct_collaborator
-lexfrei,prometheus-community,org_member
-lilic,prometheus-community,org_member
-lucperkins,prometheus-community;prometheus-community/prometheus-playground,org_member;direct_collaborator
-machine424,prometheus,org_member
-marthjod,prometheus-community;prometheus-community/elasticsearch_exporter,org_member;direct_collaborator
-martincostello,prometheus/client_java,direct_collaborator
-martinlindhe,prometheus-community;prometheus-community/windows_exporter,org_member;direct_collaborator
-matt-gp,prometheus/prometheus,direct_collaborator
-matthiasr,prometheus;prometheus-community,org_member;org_member
-MattiasGees,prometheus-community,org_member
-maximee-leroyy,prometheus-community,org_member
-maxwo,prometheus-community,org_member
-mem,prometheus;prometheus/blackbox_exporter,org_member;direct_collaborator
-metalmatze,prometheus;prometheus-community;prometheus-community/elasticsearch_exporter,org_member;org_member;direct_collaborator
-MichaHoffmann,prometheus-community/parquet-wg;prometheus-community/parquet-common;prometheus-community/parmetheus,direct_collaborator;direct_collaborator;direct_collaborator
-monotek,prometheus-community,org_member
-mrueg,prometheus-community,org_member
-mrvarmazyar,prometheus/prometheus,direct_collaborator
-mxinden,prometheus;prometheus-community;prometheus/client_rust,org_member;org_member;direct_collaborator
-naseemkullah,prometheus-community,org_member
-nevill,prometheus-community;prometheus-community/prometheus,org_member;direct_collaborator
-Nexucis,prometheus;prometheus-community,org_member;org_member
-NiceGuyIT,prometheus-community,org_member
-nlamirault,prometheus-community,org_member
-npazosmendez,prometheus;prometheus-community/parquet-common,org_member;direct_collaborator
-okgolove,prometheus-community,org_member
-openenergyprojects,prometheus-community,org_member
-paulfantom,prometheus;prometheus-community;prometheus/demo-site,org_member;org_member;direct_collaborator
-pedro-stanaka,prometheus,org_member
-pgier,prometheus;prometheus/procfs,org_member;direct_collaborator
-povilasv,prometheus-community;prometheus-community/community,org_member;direct_collaborator
-QuentinBisson,prometheus-community,org_member
-rajagopalanand,prometheus,org_member
-rakyll,prometheus-community,org_member
-rayram23,prometheus-community,org_member
-remyleone,prometheus/prometheus,direct_collaborator
-rexagod,prometheus/prometheus,direct_collaborator
-RichiH,prometheus;prometheus-community,org_member;org_member
-roidelapluie,prometheus;prometheus-community,org_member;org_member
-rpahli,prometheus-community,org_member
-rsicart,prometheus-community,org_member
-rsotnychenko,prometheus-community,org_member
-rustycl0ck,prometheus-community,org_member
-s-urbaniak,prometheus-community,org_member
-saswatamcode,prometheus;prometheus-community/avalanche,org_member;direct_collaborator
-scDisorder,prometheus-community,org_member
-schmiddim,prometheus-community,org_member
-scottrigby,prometheus-community,org_member
-secustor,prometheus-community/fortigate_exporter,direct_collaborator
-Sheridan,prometheus-community,org_member
-siavashs,prometheus,org_member
-simonfrey,prometheus-community;prometheus-community/elasticsearch_exporter,org_member;direct_collaborator
-simonpasquier,prometheus;prometheus-community;prometheus/circleci;prometheus-community/vscode-promql,org_member;org_member;direct_collaborator;direct_collaborator
-Sinjo,prometheus;prometheus/client_ruby,org_member;direct_collaborator
-slrtbtfs,prometheus-community;prometheus-community/promql-langserver;prometheus-community/vscode-promql,org_member;direct_collaborator;direct_collaborator
-SoloJacobs,prometheus,org_member
-Spaceman1701,prometheus,org_member
-squat,prometheus-community;prometheus-community/promql-langserver;prometheus-community/vscode-promql,org_member;direct_collaborator;direct_collaborator
-stanhu,prometheus-community,org_member
-steven-sheehy,prometheus-community,org_member
-stewartshea,prometheus-community,org_member
-stuartnelson3,prometheus-community,org_member
-SuperQ,prometheus;prometheus-community;prometheus/statsd_exporter;prometheus/talks,org_member;org_member;direct_collaborator;direct_collaborator
-svenmueller,prometheus-community,org_member
-sysadmind,prometheus;prometheus-community,org_member;org_member
-tariq1890,prometheus-community,org_member
-thelinuxfoundation,prometheus,org_member
-TheMeier,prometheus,org_member
-thomaspeitz,prometheus;prometheus-community,org_member;org_member
-timm088,prometheus-community,org_member
-tombrk,prometheus,org_member
-tomwilkie,prometheus;prometheus-community;prometheus/compliance,org_member;org_member;direct_collaborator
-torstenwalter,prometheus-community,org_member
-tristanburgess,prometheus-community,org_member
-ultrotter,prometheus,org_member
-vesari,prometheus;prometheus-community,org_member;org_member
-vsliouniaev,prometheus-community,org_member
-w0rm,prometheus,org_member
-walker-tom,prometheus-community,org_member
-waltherlee,prometheus,org_member
-wilfriedroset,prometheus-community,org_member
-wrouesnel,prometheus-community,org_member
-xiu,prometheus-community,org_member
-Xtigyro,prometheus-community,org_member
-yaacov,prometheus;prometheus/prometheus_api_client_ruby,org_member;direct_collaborator
-yeya24,prometheus-community/parquet-common,direct_collaborator
-ywwg,prometheus,org_member
-zanhsieh,prometheus-community,org_member
-zeitlinger,prometheus;prometheus/client_java;prometheus/jmx_exporter,org_member;direct_collaborator;direct_collaborator
-zeritti,prometheus-community,org_member
-zwopir,prometheus-community;prometheus-community/elasticsearch_exporter,org_member;direct_collaborator
-
+# Generated at: 2026-05-26T14:27:04Z
+login,sources,access_types,name,email
+acondrat,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,acondrat,arcadie.condrat@gmail.com
+aknuds1,prometheus;prometheus/prometheus;prometheus/otlptranslator;prometheus-community/prometheus,org_member;maintainer;maintainer;maintainer,Arve Knudsen,arve.knudsen@gmail.com
+alanprot,prometheus-community/parquet-common,direct_collaborator,,
+aleroyer,prometheus-community;prometheus-community/rsyslog_exporter;prometheus-community/rsyslog_exporter,org_member;direct_collaborator;maintainer,Antoine Leroyer,
+alexgreenbank,prometheus;prometheus/prometheus;prometheus/prometheus;prometheus-community/prometheus;prometheus-community/prometheus,org_member;maintainer;maintainer;maintainer;maintainer,Alex Greenbank,alexgreenbank@yahoo.com
+amy-super,prometheus-community/ux-research;prometheus-community/ux-research,direct_collaborator;maintainer,Amy Super,amy.super@grafana.com
+AndrejKiri,prometheus-community/ux-research;prometheus-community/ux-research,direct_collaborator;maintainer,Andrej Kiripolsky,andrej.kiripolsky@gmail.com
+andrewgkew,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,andrewgkew,andrew@quadcorps.co.uk
+andriikushch,prometheus-community;prometheus-community/yet-another-cloudwatch-exporter;prometheus-community/helm-charts,org_member;maintainer;maintainer,Andrii Kushch,andrii.kushch@grafana.com
+ant31,prometheus-community/vscode-promql,direct_collaborator,,
+apricote,prometheus/prometheus,direct_collaborator,,
+arslanbekov,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,arslanbekov,arslanbekov@gmail.com
+arthlr,prometheus-community,org_member,,
+ArthurSens,prometheus;prometheus-community;prometheus/client_golang;prometheus/prometheus;prometheus/otlptranslator;prometheus-community/prometheus;prometheus-community/ux-research,org_member;org_member;direct_collaborator;maintainer;maintainer;maintainer;maintainer,Arthur Silva Sens;Arthur Sens,arthursens2005@gmail.com
+asherf,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,asherf,asher@asherfoa.com
+bastischubert,prometheus;prometheus-community;prometheus/snmp_exporter;prometheus/snmp_exporter;prometheus-community/snmp;prometheus-community/fortigate_exporter,org_member;org_member;direct_collaborator;maintainer;maintainer;maintainer,Basti Schubert,basti@schubert.digital
+bboreham,prometheus;prometheus/prometheus;prometheus-community/prometheus,org_member;maintainer;maintainer,Bryan Boreham,bjboreham@gmail.com
+bitfehler,prometheus;prometheus-community;prometheus-community/ipmi_exporter;prometheus-community/smartctl_exporter,org_member;org_member;maintainer;maintainer,Conrad Hoffmann,ch@bitfehler.net
+bluecmd,prometheus-community;prometheus-community/fortigate_exporter,org_member;direct_collaborator,,
+brancz,prometheus;prometheus-community;prometheus-community/prom-label-proxy;prometheus/prometheus;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;org_member;direct_collaborator;maintainer;maintainer;maintainer,Frederic Branczyk,fbranczyk@gmail.com
+breed808,prometheus;prometheus-community;prometheus-community/windows_exporter,org_member;org_member;maintainer,Ben Reedy,breed808@breed808.com
+bwplotka,prometheus;prometheus-community;prometheus/proposals;prometheus/prometheus;prometheus/client_golang;prometheus/client_model;prometheus/prom2json;prometheus/test-infra;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/avalanche;prometheus-community/prometheus,org_member;org_member;direct_collaborator;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Bartłomiej Płotka;Bartek Plotka;Bartek Płotka,bwplotka@gmail.com
+caarlos0,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,caarlos0,carlos@carlosbecker.com
+caniszczyk,prometheus;prometheus-community,org_member;org_member,,
+carlpett,prometheus;prometheus-community;prometheus-community/windows_exporter,org_member;org_member;direct_collaborator,,
+carrieedwards,prometheus;prometheus/prometheus;prometheus-community/prometheus,org_member;maintainer;maintainer,Carrie Edwards,carrie.edwards@grafana.com
+celian-garcia,prometheus-community;prometheus-community/highlightjs-promql;prometheus-community/monaco-promql;prometheus-community/highlightjs-promql,org_member;direct_collaborator;maintainer;maintainer,Célian Garcia,celian.garcia1@gmail.com
+codesome,prometheus;prometheus-community;prometheus/prometheus;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;org_member;maintainer;maintainer;maintainer,Ganesh Vernekar,ganesh@grafana.com
+cristiangreco,prometheus;prometheus-community;prometheus-community/yet-another-cloudwatch-exporter;prometheus-community/helm-charts,org_member;org_member;maintainer;maintainer,Cristian Greco,cristian.greco@grafana.com
+csmarchbanks,prometheus;prometheus-community;prometheus/client_python;prometheus/prometheus-ghsa-p54f-935g-x7j2,org_member;org_member;maintainer;maintainer,Chris Marchbanks,csmarchbanks@gmail.com
+cstaud,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,cstaud,christian.staude@staffbase.com
+cstyan,prometheus;prometheus-community;prometheus/prometheus;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;org_member;maintainer;maintainer;maintainer,Callum Styan,callumstyan@gmail.com
+dacamposol,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,dacamposol,dacamposol@gmail.com
+dashpole,prometheus,org_member,,
+derekmarcotte,prometheus-community,org_member,,
+desaintmartin,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer;maintainer;maintainer,desaintmartin,cedric@desaintmartin.fr
+dgl,prometheus;prometheus/prometheus;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;maintainer;maintainer;maintainer,David Leadbeater,dgl@dgl.cx
+dhoard,prometheus;prometheus/client_java;prometheus/jmx_exporter;prometheus/client_java;prometheus/jmx_exporter,org_member;direct_collaborator;direct_collaborator;maintainer;maintainer,Doug Hoard,doug.hoard@gmail.com
+discordianfish,prometheus;prometheus-community;prometheus-community/node-exporter-textfile-collector-scripts;prometheus/node_exporter;prometheus/procfs,org_member;org_member;direct_collaborator;maintainer;maintainer,Johannes 'fish' Ziemke,github@freigeist.org
+dmagliola,prometheus;prometheus/client_ruby;prometheus/client_ruby,org_member;direct_collaborator;maintainer,Daniel Magliola,dmagliola@crystalgears.com
+dongjiang1989,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,dongjiang1989,dongjiang1989@126.com
+dotdc,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,dotdc,david@0xdc.me
+DrFaust92,prometheus-community,org_member,,
+dswarbrick,prometheus;prometheus-community;prometheus-community/node-exporter-textfile-collector-scripts,org_member;org_member;maintainer,Daniel Swarbrick,daniel.swarbrick@gmail.com
+electron0zero,prometheus;prometheus/blackbox_exporter,org_member;maintainer,Suraj Nath,suraj.sidh@grafana.com
+erdii,prometheus-community,org_member,,
+fabxc,prometheus-community,org_member,,
+fionaliao,prometheus;prometheus/prometheus;prometheus-community/prometheus,org_member;maintainer;maintainer,Fiona Liao,fiona.liao@grafana.com
+francoposa,prometheus-community/parquet-common,direct_collaborator,,
+free,prometheus-community,org_member,,
+frodenas,prometheus-community,org_member,,
+fstab,prometheus;prometheus/jmx_exporter;prometheus/client_java;prometheus/jmx_exporter,org_member;direct_collaborator;maintainer;maintainer,Fabian Stäber,fabian@fstab.de
+gardar,prometheus;prometheus-community;prometheus/demo-site;prometheus/demo-site;prometheus-community/ansible,org_member;org_member;direct_collaborator;maintainer;maintainer,Garðar Arnarsson,github@gardar.net
+geekodour,prometheus-community;prometheus-community/prometheus,org_member;direct_collaborator,,
+gianrubio,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,gianrubio,gianrubio@gmail.com
+gkarthiks,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer;maintainer;maintainer,gkarthiks,github.gkarthiks@gmail.com
+GMartinez-Sisti,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,Gabriel Martinez;GMartinez-Sisti,kube-prometheus-stack@sisti.pt
+golgoth31,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,golgoth31,golgoth31@notrenet.com
+gotjosh,prometheus;prometheus/alertmanager;prometheus/common;prometheus/sigv4;prometheus/common-ghsa-qmwc-fc99-jm3h,org_member;maintainer;maintainer;maintainer;maintainer,Josue Abreu;Josue,josue.abreu@gmail.com
+gouthamve,prometheus;prometheus-community,org_member;org_member,,
+grobie,prometheus;prometheus-community;prometheus/memcached_exporter,org_member;org_member;maintainer,Tobias Schmidt,tobidt@gmail.com
+grobinson-grafana,prometheus;prometheus/alertmanager;prometheus/alertmanager,org_member;direct_collaborator;maintainer,George Robinson,george.robinson@grafana.com
+hectorj2f,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,hectorj2f,hfernandez@mesosphere.com
+iamabhishek-dubey,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,iamabhishek-dubey,abhishekbhardwaj510@gmail.com
+igaskin,prometheus-community,org_member,,
+jack-berg,prometheus/client_java,direct_collaborator,,
+jan--f,prometheus;prometheus/prometheus;prometheus/pushgateway;prometheus-community/prometheus,org_member;maintainer;maintainer;maintainer,Jan Fajerski,github@fajerski.name
+jaydeluca,prometheus/client_java;prometheus/jmx_exporter;prometheus/client_java,direct_collaborator;direct_collaborator;maintainer,Jay DeLuca,jaydeluca4@gmail.com
+JessicaGreben,prometheus-community,org_member,,
+jesusvazquez,prometheus;prometheus-community;prometheus/prometheus;prometheus/prometheus;prometheus/prometheus;prometheus/otlptranslator;prometheus-community/prometheus;prometheus-community/prometheus;prometheus-community/prometheus,org_member;org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Jesús Vázquez,jesus.vazquez@grafana.com
+jkroepke,prometheus;prometheus-community;prometheus/prometheus;prometheus-community/windows_exporter;prometheus-community/prometheus;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Jan-Otto Kröpke;jkroepke,mail@jkroepke.de;github@jkroepke.de
+jooola,prometheus/prometheus;prometheus/prometheus;prometheus-community/prometheus,direct_collaborator;maintainer;maintainer,,
+Juanchimienti,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,juanchimienti,juan.chimienti@gmail.com
+juliusv,prometheus;prometheus-community;prometheus/prometheus;prometheus/docs;prometheus/collectd_exporter;prometheus/compliance;prometheus/promlens;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Julius Volz,julius.volz@gmail.com
+kakkoyun,prometheus;prometheus/client_golang;prometheus/promu;prometheus/test-infra,org_member;maintainer;maintainer;maintainer,Kemal Akkoyun,kakkoyun@gmail.com
+kawamuray,prometheus-community,org_member,,
+kfox1111,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,kfox1111,
+kgeckhart,prometheus-community;prometheus/prometheus;prometheus-community/stackdriver_exporter,org_member;maintainer;maintainer,Kyle Eckhart,kyle.eckhart@grafana.com;kgeckhart@gmail.com
+krajorama,prometheus;prometheus/prometheus;prometheus-community/prometheus,org_member;maintainer;maintainer,György Krajcsovits,gyorgy.krajcsovits@grafana.com
+krisztianfekete,prometheus/client_rust;prometheus/client_rust,direct_collaborator;maintainer,Krisztian Fekete,prometheus@krisztianfekete.org
+ldufr,prometheus/test-sd-ownership,direct_collaborator,,
+lexfrei,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,lexfrei,f@lex.la
+lilic,prometheus-community,org_member,,
+lucperkins,prometheus-community;prometheus-community/prometheus-playground,org_member;direct_collaborator,,
+machine424,prometheus;prometheus/prometheus;prometheus/pushgateway;prometheus-community/prometheus,org_member;maintainer;maintainer;maintainer,Ayoub Mrini,ayoubmrini424@gmail.com
+marthjod,prometheus-community;prometheus-community/elasticsearch_exporter,org_member;direct_collaborator,,
+martincostello,prometheus/client_java,direct_collaborator,,
+martinlindhe,prometheus-community;prometheus-community/windows_exporter,org_member;direct_collaborator,,
+matt-gp,prometheus/prometheus,direct_collaborator,,
+matthiasr,prometheus;prometheus-community;prometheus/statsd_exporter;prometheus/cloudwatch_exporter,org_member;org_member;maintainer;maintainer,Matthias Rampke,matthias@prometheus.io
+MattiasGees,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,mattiasgees,mattias.gees@jetstack.io
+maximee-leroyy,prometheus-community,org_member,,
+maxwo,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,maxwo,maxime.wojtczak.pub@icloud.com
+mem,prometheus;prometheus/blackbox_exporter;prometheus/blackbox_exporter,org_member;direct_collaborator;maintainer,Marcelo Magallon,marcelo.magallon@grafana.com
+metalmatze,prometheus;prometheus-community;prometheus-community/elasticsearch_exporter;prometheus/prometheus;prometheus-community/prometheus;prometheus-community/pro-bing,org_member;org_member;direct_collaborator;maintainer;maintainer;maintainer,Matthias Loibl,mail@matthiasloibl.com
+MichaHoffmann,prometheus-community/parquet-wg;prometheus-community/parquet-common;prometheus-community/parmetheus,direct_collaborator;direct_collaborator;direct_collaborator,,
+monotek,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,André Bauer;monotek,monotek23@gmail.com
+mrueg,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,mrueg,manuel@rueg.eu
+mrvarmazyar,prometheus/prometheus;prometheus/prometheus;prometheus-community/prometheus,direct_collaborator;maintainer;maintainer,Mohammad Varmazyar,mrvarmazyar@gmail.com
+mxinden,prometheus;prometheus-community;prometheus/client_rust,org_member;org_member;direct_collaborator,,
+naseemkullah,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,naseemkullah,naseem@transit.app
+nevill,prometheus-community;prometheus-community/prometheus,org_member;direct_collaborator,,
+Nexucis,prometheus;prometheus-community;prometheus/prometheus;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;org_member;maintainer;maintainer;maintainer,Augustin Husson,husson.augustin@gmail.com
+NiceGuyIT,prometheus-community;prometheus-community/smartctl_exporter,org_member;maintainer,David Randall,David@NiceGuyIT.biz
+nlamirault,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,nlamirault,nicolas.lamirault@gmail.com
+npazosmendez,prometheus;prometheus-community/parquet-common;prometheus/prometheus;prometheus-community/prometheus,org_member;direct_collaborator;maintainer;maintainer,Nico Pazos,nicolas.pazos-mendez@grafana.com
+okgolove,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,okgolove,okgolove@markeloff.net
+openenergyprojects,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,openenergyprojects,openenergyprojects@gmail.com
+paulfantom,prometheus;prometheus-community;prometheus/demo-site;prometheus/demo-site;prometheus-community/ansible,org_member;org_member;direct_collaborator;maintainer;maintainer,Paweł Krupa,paulfantom@gmail.com
+pedro-stanaka,prometheus;prometheus/statsd_exporter;prometheus/graphite_exporter,org_member;maintainer;maintainer,Pedro Tanaka,me@pedrotanaka.com.br
+pgier,prometheus;prometheus/procfs;prometheus/procfs,org_member;direct_collaborator;maintainer,Paul Gier,paulgier@gmail.com
+povilasv,prometheus-community;prometheus-community/community,org_member;direct_collaborator,,
+QuentinBisson,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,QuentinBisson,quentin.bisson@gmail.com
+rajagopalanand,prometheus,org_member,,
+rakyll,prometheus-community,org_member,,
+rayram23,prometheus-community,org_member,,
+remyleone,prometheus/prometheus;prometheus/prometheus;prometheus-community/prometheus,direct_collaborator;maintainer;maintainer,Rémy Léone,rleone@scaleway.com
+rexagod,prometheus/prometheus;prometheus/prometheus;prometheus-community/prometheus,direct_collaborator;maintainer;maintainer,Pranshu Srivastava,rexagod@gmail.com
+RichiH,prometheus;prometheus-community;prometheus/docs;prometheus/snmp_exporter;prometheus/promcon;prometheus/talks;prometheus/snmp_exporter_mibs;prometheus/compliance;prometheus-community/snmp,org_member;org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,"Richard Hartmann;Richard ""RichiH"" Hartmann",richih@richih.org
+roidelapluie,prometheus;prometheus-community;prometheus/prometheus;prometheus/common;prometheus/blackbox_exporter;prometheus/exporter-toolkit;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus/sigv4;prometheus/common-ghsa-qmwc-fc99-jm3h;prometheus-community/prometheus,org_member;org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Julien Pivotto,roidelapluie@prometheus.io
+rpahli,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,rpahli,pahli88@googlemail.com
+rsicart,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,rsicart,roger.sicart@gmail.com
+rsotnychenko,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,rsotnychenko,me@sota.sh
+rustycl0ck,prometheus-community;prometheus-community/json_exporter,org_member;maintainer,Ravi,rustyclock@protonmail.com
+s-urbaniak,prometheus-community,org_member,,
+saswatamcode,prometheus;prometheus-community/avalanche;prometheus-community/avalanche,org_member;direct_collaborator;maintainer,Saswata Mukherjee,saswata.mukhe@gmail.com
+scDisorder,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,scDisorder,d@rovergulf.net
+schmiddim,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,schmiddim,schmiddim@gmx.at
+scottrigby,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,Scott Rigby,scott@r6by.com
+secustor,prometheus-community/fortigate_exporter,direct_collaborator,,
+Sheridan,prometheus-community,org_member,,
+siavashs,prometheus;prometheus/alertmanager,org_member;maintainer,Siavash Safi,siavash@cloudflare.com
+simonfrey,prometheus-community;prometheus-community/elasticsearch_exporter,org_member;direct_collaborator,,
+simonpasquier,prometheus;prometheus-community;prometheus/circleci;prometheus-community/vscode-promql;prometheus/prometheus;prometheus/alertmanager;prometheus/consul_exporter;prometheus/circleci;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prom-label-proxy;prometheus-community/prometheus,org_member;org_member;direct_collaborator;direct_collaborator;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Simon Pasquier,pasquier.simon@gmail.com
+Sinjo,prometheus;prometheus/client_ruby,org_member;direct_collaborator,,
+slrtbtfs,prometheus-community;prometheus-community/promql-langserver;prometheus-community/vscode-promql,org_member;direct_collaborator;direct_collaborator,,
+SoloJacobs,prometheus;prometheus/alertmanager,org_member;maintainer,Solomon Jacobs,solomonjacobs@protonmail.com
+Spaceman1701,prometheus;prometheus/alertmanager,org_member;maintainer,Ethan Hunter,fc.spaceman@gmail.com
+squat,prometheus-community;prometheus-community/promql-langserver;prometheus-community/vscode-promql;prometheus-community/prom-label-proxy,org_member;direct_collaborator;direct_collaborator;maintainer,Lucas Servén Marín,lserven@gmail.com
+stanhu,prometheus-community;prometheus-community/pgbouncer_exporter,org_member;maintainer,Stan Hu,stanhu@gmail.com
+steven-sheehy,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,steven-sheehy,ssheehy@firescope.com
+stewartshea,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,stewartshea,stewart.shea@gmail.com
+stuartnelson3,prometheus-community,org_member,,
+SuperQ,prometheus;prometheus-community;prometheus/statsd_exporter;prometheus/talks;prometheus/prometheus;prometheus/node_exporter;prometheus/client_ruby;prometheus/procfs;prometheus/snmp_exporter;prometheus/mysqld_exporter;prometheus/talks;prometheus/demo-site;prometheus/exporter-toolkit;prometheus/snmp_exporter_mibs;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/elasticsearch_exporter;prometheus-community/postgres_exporter;prometheus-community/bind_exporter;prometheus-community/json_exporter;prometheus-community/stackdriver_exporter;prometheus-community/pgbouncer_exporter;prometheus-community/ipmi_exporter;prometheus-community/snmp;prometheus-community/node-exporter-textfile-collector-scripts;prometheus-community/smartctl_exporter;prometheus-community/prometheus;prometheus-community/fortigate_exporter;prometheus-community/pro-bing;prometheus-community/ansible,org_member;org_member;direct_collaborator;direct_collaborator;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,Ben Kochie,superq@gmail.com
+svenmueller,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,svenmueller,sven.mueller@commercetools.com
+sysadmind,prometheus;prometheus-community;prometheus-community/elasticsearch_exporter;prometheus-community/postgres_exporter,org_member;org_member;maintainer;maintainer,Joe Adams,github@joeadams.io
+tariq1890,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,tariq1890,tariq.ibrahim@mulesoft.com
+thelinuxfoundation,prometheus,org_member,,
+TheMeier,prometheus,org_member,,
+thomaspeitz,prometheus;prometheus-community;prometheus-community/yet-another-cloudwatch-exporter;prometheus-community/helm-charts,org_member;org_member;maintainer;maintainer,Thomas Peitz,info@thomas-peitz.de
+timm088,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,timm088,8890118+timm088@users.noreply.github.com
+tombrk,prometheus,org_member,,
+tomwilkie,prometheus;prometheus-community;prometheus/compliance;prometheus/prometheus;prometheus/compliance;prometheus/prometheus-ghsa-p54f-935g-x7j2;prometheus-community/prometheus,org_member;org_member;direct_collaborator;maintainer;maintainer;maintainer;maintainer,Tom Wilkie,tom.wilkie@gmail.com
+torstenwalter,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,Torsten Walter;torstenwalter,mail@torstenwalter.de
+tristanburgess,prometheus-community;prometheus-community/yet-another-cloudwatch-exporter;prometheus-community/helm-charts,org_member;maintainer;maintainer,Tristan Burgess,tristan.burgess@grafana.com
+ultrotter,prometheus;prometheus/alertmanager,org_member;maintainer,Guido Trotter,ultrotter@gmail.com
+vesari,prometheus;prometheus-community;prometheus/client_golang,org_member;org_member;maintainer,Arianna Vespri,arianna.vespri@proton.me
+vsliouniaev,prometheus-community,org_member,,
+w0rm,prometheus;prometheus/alertmanager,org_member;maintainer,Andrey Kuzmin,unsoundscapes@gmail.com
+walker-tom,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,walker-tom,walker.thomas.p@gmail.com
+waltherlee,prometheus,org_member,,
+wilfriedroset,prometheus-community;prometheus-community/helm-charts,org_member;maintainer,wilfriedroset,
+wrouesnel,prometheus-community;prometheus-community/postgres_exporter,org_member;maintainer,William Rouesnel,wrouesnel@wrouesnel.com
+xiu,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,xiu,github@xiu.io
+Xtigyro,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer,Xtigyro,miroslav.hadzhiev@gmail.com
+yaacov,prometheus;prometheus/prometheus_api_client_ruby;prometheus/prometheus_api_client_ruby,org_member;direct_collaborator;maintainer,Yaacov Zamir,kobi.zamir@gmail.com
+yeya24,prometheus-community/parquet-common,direct_collaborator,,
+ywwg,prometheus;prometheus/prometheus;prometheus/otlptranslator;prometheus-community/prometheus,org_member;maintainer;maintainer;maintainer,Owen Williams,owen.williams@grafana.com
+zanhsieh,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,zanhsieh,zanhsieh@gmail.com
+zeitlinger,prometheus;prometheus/client_java;prometheus/jmx_exporter;prometheus/client_java,org_member;direct_collaborator;direct_collaborator;maintainer,Gregor Zeitlinger,gregor.zeitlinger@grafana.com
+zeritti,prometheus-community;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts;prometheus-community/helm-charts,org_member;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer;maintainer,zeritti,rootsandtrees@posteo.de
+zwopir,prometheus-community;prometheus-community/elasticsearch_exporter,org_member;direct_collaborator,,


### PR DESCRIPTION
## What

Extends the 2026 `voters-list` tool (`collect-write-access`) to harvest **names and emails** from each repo's root `MAINTAINERS(.md)` file, in addition to the existing GitHub logins with write access. A login alone gives no way to contact a voter or confirm identity.

## Changes

- **Parse** names/emails/handles from `MAINTAINERS.md`/`MAINTAINER.md`. The parser is best-effort and handles every format in the ecosystem (`Name <email> @handle`, `Name (email / @handle)`, markdown profile links `[Name](https://github.com/handle)`, `Name (handle) - email`, component-scoped and multi-maintainer lines). It skips alumni/former-maintainer sections.
- **Enrich** `write-access.csv` / `write-access-raw.csv` with `name`,`email` columns by matching maintainer handle → login (case-insensitive). No new voters are added here.
- **New** `maintainers-without-write-access.csv`: maintainers listed in a MAINTAINERS file but not in the write-access set (reported, *not* enrolled as voters).
- **New** `email-to-github.csv` config (`-mapping` flag): maps maintainer email → GitHub login, to resolve entries listed by name+email only (no `@handle`). Seeded with 7 verified mappings.
- **Manifest** gains `maintainers_file` provenance entries.
- **Tests** for the parser and the mapping loader.
- Regenerated data files.

## Result

- 115 of 172 voters now carry an email.
- The email mapping resolves 7 maintainers (org members listed by name+email only), shrinking `maintainers-without-write-access.csv` from 14 → 7.

## Notes for review

- The `email-to-github.csv` seed mappings cover only well-known identities that resolve into the current write-access set — please sanity-check them.
- Parsing is intentionally best-effort; the one known miss is a prose intro line in `prometheus/prometheus` (those people are org members and thus voters regardless — only name/email enrichment is affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)