### PR TITLE
fix: link to correct URL

### DIFF
--- a/elections/2026/candidate-ArthurSens.md
+++ b/elections/2026/candidate-ArthurSens.md
@@ -11,7 +11,7 @@ info:
 - [x] I have read the
   [Governance document](https://github.com/prometheus/governance/blob/main/GOVERNANCE.md)
   and the
-  [Code of Conduct](https://github.com/prometheus/docs/blob/main/code-of-conduct.md),
+  [Code of Conduct](https://github.com/prometheus/docs/blob/main/CODE_OF_CONDUCT.md),
   and agree to uphold them if elected.
 
 ## Teams

--- a/elections/2026/candidate-SuperQ.md
+++ b/elections/2026/candidate-SuperQ.md
@@ -12,7 +12,7 @@ info:
 - [x] I have read the
   [Governance document](https://github.com/prometheus/governance/blob/main/GOVERNANCE.md)
   and the
-  [Code of Conduct](https://github.com/prometheus/docs/blob/main/code-of-conduct.md),
+  [Code of Conduct](https://github.com/prometheus/docs/blob/main/CODE_OF_CONDUCT.md),
   and agree to uphold them if elected.
 
 ## Teams

--- a/elections/2026/candidate-aknuds1.md
+++ b/elections/2026/candidate-aknuds1.md
@@ -11,7 +11,7 @@ info:
 - [x] I have read the
   [Governance document](https://github.com/prometheus/governance/blob/main/GOVERNANCE.md)
   and the
-  [Code of Conduct](https://github.com/prometheus/docs/blob/main/code-of-conduct.md),
+  [Code of Conduct](https://github.com/prometheus/docs/blob/main/CODE_OF_CONDUCT.md),
   and agree to uphold them if elected.
 
 ## Teams

--- a/elections/2026/candidate-jan--f.md
+++ b/elections/2026/candidate-jan--f.md
@@ -11,7 +11,7 @@ info:
 - [x] I have read the
   [Governance document](https://github.com/prometheus/governance/blob/main/GOVERNANCE.md)
   and the
-  [Code of Conduct](https://github.com/prometheus/docs/blob/main/code-of-conduct.md),
+  [Code of Conduct](https://github.com/prometheus/docs/blob/main/CODE_OF_CONDUCT.md),
   and agree to uphold them if elected.
 
 ## Teams

--- a/elections/2026/nomination-template.md
+++ b/elections/2026/nomination-template.md
@@ -24,7 +24,7 @@ Reminders, per https://github.com/prometheus/governance/blob/main/GOVERNANCE.md:
 - [ ] I have read the
   [Governance document](https://github.com/prometheus/governance/blob/main/GOVERNANCE.md)
   and the
-  [Code of Conduct](https://github.com/prometheus/docs/blob/main/code-of-conduct.md),
+  [Code of Conduct](https://github.com/prometheus/docs/blob/main/CODE_OF_CONDUCT.md),
   and agree to uphold them if elected.
 
 ## Teams


### PR DESCRIPTION
The previous URL returns a 404. We could also consider directly linking to the CNCF document.